### PR TITLE
Make Workers aware of CORE Processors

### DIFF
--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -135,7 +135,7 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
      */
     @Override
     public String getConnectionInfo() throws Exception {
-        return String.format("Cluster Name - %s : Keyspace Name - %s : CF Name - %s ::: ReadCL - %s : WriteCL - %s ", ClusterName, KeyspaceName, TableName, "", ""); //ReadConsistencyLevel, WriteConsistencyLevel);
+        return String.format("Cluster Name - %s : Keyspace Name - %s : CF Name - %s ::: ReadCL - %s : WriteCL - %s ", ClusterName, KeyspaceName, TableName, ReadConsistencyLevel, WriteConsistencyLevel);
     }
 
     /**

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -40,7 +40,8 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
     private DataGenerator dataGenerator;
 
     private String ClusterName = "Localhost", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
-    private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.LOCAL_ONE, ReadConsistencyLevel=ConsistencyLevel.LOCAL_ONE;
+    // private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.LOCAL_ONE, ReadConsistencyLevel=ConsistencyLevel.LOCAL_ONE;
+    private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.ONE, ReadConsistencyLevel=ConsistencyLevel.ONE;
 
     private PreparedStatement readPstmt;
     private PreparedStatement writePstmt;

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -86,7 +86,7 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
     public String readSingle(String key) throws Exception {
         BoundStatement bStmt = readPstmt.bind();
         bStmt.setString("\"_id\"", key);
-        //bStmt.setConsistencyLevel(this.ReadConsistencyLevel);
+        bStmt.setConsistencyLevel(this.ReadConsistencyLevel);
         ResultSet rs = session.execute(bStmt);
 
         List<Row> result=rs.all();

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -39,10 +39,10 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
 
     private DataGenerator dataGenerator;
 
-    //private String ClusterName = "Localhost", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
-    private String ClusterName = "Test Cluster", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
+    private String ClusterName = "Localhost", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
+    //private String ClusterName = "Test Cluster", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
         
-    // private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.LOCAL_ONE, ReadConsistencyLevel=ConsistencyLevel.LOCAL_ONE;
+    private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.LOCAL_ONE, ReadConsistencyLevel=ConsistencyLevel.LOCAL_ONE;
 
     private PreparedStatement readPstmt;
     private PreparedStatement writePstmt;
@@ -115,7 +115,7 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
         BoundStatement bStmt = writePstmt.bind();
         bStmt.setString("\"_id\"", key);
         bStmt.setList("name", Arrays.asList(this.dataGenerator.getRandomValue())) ;
-        //bStmt.setConsistencyLevel(this.WriteConsistencyLevel);
+        bStmt.setConsistencyLevel(this.WriteConsistencyLevel);
 
         session.execute(bStmt);
         return ResultOK;
@@ -149,8 +149,8 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
     }
 
     void upsertKeyspace(Session session) {
-        //session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '1'}  AND durable_writes = true;");
-        session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class':'SimpleStrategy','replication_factor': 2};");
+        session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '1'}  AND durable_writes = true;");
+        //session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class':'SimpleStrategy','replication_factor': 2};");
         session.execute("Use " + KeyspaceName);
     }
     
@@ -168,6 +168,6 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
         		       " AND min_index_interval = 128 " + 
         		       " AND read_repair_chance = 0.0 " + 
         		       " AND speculative_retry = '99.0PERCENTILE'; ");
-        //session.execute("CREATE CUSTOM INDEX IF NOT EXISTS elastic_external_name_idx ON customer.external (name) USING 'org.elasticsearch.cassandra.index.ExtendedElasticSecondaryIndex';");
+        session.execute("CREATE CUSTOM INDEX IF NOT EXISTS elastic_external_name_idx ON customer.external (name) USING 'org.elasticsearch.cassandra.index.ExtendedElasticSecondaryIndex';");
     }
 }

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -164,6 +164,6 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
         		       " AND min_index_interval = 128 " + 
         		       " AND read_repair_chance = 0.0 " + 
         		       " AND speculative_retry = '99.0PERCENTILE'; ");
-        session.execute("CREATE CUSTOM INDEX IF NOT EXISTS elastic_external_name_idx ON customer.external (name) USING 'org.elasticsearch.cassandra.index.ExtendedElasticSecondaryIndex';");
+        //session.execute("CREATE CUSTOM INDEX IF NOT EXISTS elastic_external_name_idx ON customer.external (name) USING 'org.elasticsearch.cassandra.index.ExtendedElasticSecondaryIndex';");
     }
 }

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -147,9 +147,11 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
     }
 
     void upsertKeyspace(Session session) {
-        session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '1'}  AND durable_writes = true;");
+        //session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '1'}  AND durable_writes = true;");
+        session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class':'SimpleStrategy','replication_factor':1};");
         session.execute("Use " + KeyspaceName);
     }
+    
     void upsertCF(Session session) {
         session.execute("CREATE TABLE IF NOT EXISTS "+ TableName +" (\"_id\" text PRIMARY KEY, name list<text>) WITH bloom_filter_fp_chance = 0.01 " + 
         		       " AND caching = '{\"keys\":\"ALL\", \"rows_per_partition\":\"NONE\"}'" + 

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -39,7 +39,9 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
 
     private DataGenerator dataGenerator;
 
-    private String ClusterName = "Localhost", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
+    //private String ClusterName = "Localhost", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
+    private String ClusterName = "Test Cluster", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
+        
     // private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.LOCAL_ONE, ReadConsistencyLevel=ConsistencyLevel.LOCAL_ONE;
     private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.ONE, ReadConsistencyLevel=ConsistencyLevel.ONE;
 

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -43,7 +43,6 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
     private String ClusterName = "Test Cluster", ClusterContactPoint ="172.28.198.16", KeyspaceName ="customer", TableName ="external";
         
     // private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.LOCAL_ONE, ReadConsistencyLevel=ConsistencyLevel.LOCAL_ONE;
-    private ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.ONE, ReadConsistencyLevel=ConsistencyLevel.ONE;
 
     private PreparedStatement readPstmt;
     private PreparedStatement writePstmt;
@@ -87,7 +86,7 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
     public String readSingle(String key) throws Exception {
         BoundStatement bStmt = readPstmt.bind();
         bStmt.setString("\"_id\"", key);
-        bStmt.setConsistencyLevel(this.ReadConsistencyLevel);
+        //bStmt.setConsistencyLevel(this.ReadConsistencyLevel);
         ResultSet rs = session.execute(bStmt);
 
         List<Row> result=rs.all();
@@ -116,7 +115,7 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
         BoundStatement bStmt = writePstmt.bind();
         bStmt.setString("\"_id\"", key);
         bStmt.setList("name", Arrays.asList(this.dataGenerator.getRandomValue())) ;
-        bStmt.setConsistencyLevel(this.WriteConsistencyLevel);
+        //bStmt.setConsistencyLevel(this.WriteConsistencyLevel);
 
         session.execute(bStmt);
         return ResultOK;
@@ -136,7 +135,7 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
      */
     @Override
     public String getConnectionInfo() throws Exception {
-        return String.format("Cluster Name - %s : Keyspace Name - %s : CF Name - %s ::: ReadCL - %s : WriteCL - %s ", ClusterName, KeyspaceName, TableName, ReadConsistencyLevel, WriteConsistencyLevel);
+        return String.format("Cluster Name - %s : Keyspace Name - %s : CF Name - %s ::: ReadCL - %s : WriteCL - %s ", ClusterName, KeyspaceName, TableName, "", ""); //ReadConsistencyLevel, WriteConsistencyLevel);
     }
 
     /**
@@ -151,7 +150,7 @@ public class ElassandraCassJavaDriverPlugin implements NdBenchClient{
 
     void upsertKeyspace(Session session) {
         //session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '1'}  AND durable_writes = true;");
-        session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class':'SimpleStrategy','replication_factor':1};");
+        session.execute("CREATE KEYSPACE IF NOT EXISTS " + KeyspaceName +" WITH replication = {'class':'SimpleStrategy','replication_factor': 2};");
         session.execute("Use " + KeyspaceName);
     }
     

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/config/NdBenchConfiguration.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/config/NdBenchConfiguration.java
@@ -34,8 +34,8 @@ public class NdBenchConfiguration implements IConfiguration {
     private static final Integer DEFAULT_NUM_KEYS = 1000;
     private static final Integer DEFAULT_NUM_VALUES = 100;
     private static final Integer DEFAULT_DATA_SIZE = 128;
-    private static final Integer DEFAULT_NUM_WRITERS = 1;
-    private static final Integer DEFAULT_NUM_READERS = 1;
+    private static final Integer DEFAULT_NUM_WRITERS = Runtime.getRuntime().availableProcessors() * 4;
+    private static final Integer DEFAULT_NUM_READERS = Runtime.getRuntime().availableProcessors() * 4;
     private static final Integer DEFAULT_NUM_BACKFILL = 1;
     private static final Integer DEFAULT_BACKFILL_START_KEY = 1;
     private static final Boolean DEFAULT_WRITE_ENABLED = true;
@@ -48,8 +48,6 @@ public class NdBenchConfiguration implements IConfiguration {
     private static final Integer DEFAULT_DATASIZE_LOWERBOUND = 1000;
     private static final Integer DEFAULT_DATASIZE_UPPERBOUND = 5000;
     private static final Boolean DEFAULT_USE_STATIC_DATA = false;
-
-
 
     //Config Prop Names
     private static final String CONFIG_NUM_KEYS = NdBenchConstants.PROP_PREFIX + NdBenchConstants.NUM_KEYS;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
@@ -28,6 +28,7 @@ import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
 import com.netflix.ndbench.core.config.IConfiguration;
 import com.netflix.ndbench.core.config.NdBenchConfiguration;
+import com.netflix.ndbench.core.discovery.AWSLocalClusterDiscovery;
 import com.netflix.ndbench.core.discovery.IClusterDiscovery;
 import com.netflix.ndbench.core.discovery.LocalClusterDiscovery;
 import com.netflix.ndbench.core.generators.StringDataGenerator;
@@ -47,7 +48,7 @@ public class NdBenchGuiceModule extends AbstractModule
     {
         bind(IConfiguration.class).to(NdBenchConfiguration.class);
         bind(NdBenchMonitor.class).to(FakeMonitor.class);
-        bind(IClusterDiscovery.class).to(LocalClusterDiscovery.class);
+        bind(IClusterDiscovery.class).to(AWSLocalClusterDiscovery.class);
         bind(DataGenerator.class).to(StringDataGenerator.class);
 
         //Get all implementations of NdBenchClient Interface and install them as Plugins

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
@@ -48,7 +48,8 @@ public class NdBenchGuiceModule extends AbstractModule
     {
         bind(IConfiguration.class).to(NdBenchConfiguration.class);
         bind(NdBenchMonitor.class).to(FakeMonitor.class);
-        bind(IClusterDiscovery.class).to(AWSLocalClusterDiscovery.class);
+        //bind(IClusterDiscovery.class).to(AWSLocalClusterDiscovery.class);
+        bind(IClusterDiscovery.class).to(LocalClusterDiscovery.class);
         bind(DataGenerator.class).to(StringDataGenerator.class);
 
         //Get all implementations of NdBenchClient Interface and install them as Plugins


### PR DESCRIPTION
@ipapapa @vinaykumarchella 

In regards of https://github.com/Netflix/ndbench/issues/11

I change NdBenchConfiguration to check the available processors and them multiply this result by 4. Doing So I was able to get more than **20K** RPS on Cassandra.

![cass-20k_rps](https://cloud.githubusercontent.com/assets/121278/19899708/350c59f8-a048-11e6-922d-e21325b7bfbb.png)

Cheers,
Diego Pacheco
