### PR TITLE
Adding Extended Functional Testing with JedisUtils

### DIFF
--- a/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/NdBenchClientModule.java
+++ b/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/NdBenchClientModule.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 //package com.netflix.ndbench.api.plugin;
 //
 //import com.google.inject.AbstractModule;

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.ndbench.plugin.elassandra;
 
 import java.util.Arrays;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AWSLocalClusterDiscovery.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AWSLocalClusterDiscovery.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.ndbench.core.discovery;
 
 import java.io.BufferedReader;

--- a/ndbench-dyno-plugins/build.gradle
+++ b/ndbench-dyno-plugins/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     compile project(':ndbench-api')
-    compile 'com.netflix.dyno:dyno-core:1.4.7-rc.2'
-    compile 'com.netflix.dyno:dyno-jedis:1.4.7-rc.2'
-
-
+    compile 'com.netflix.dyno:dyno-core:latest.release'
+    compile 'com.netflix.dyno:dyno-jedis:latest.release'
+    compile 'com.netflix.dyno:dyno-contrib:latest.release'
 }

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedis.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedis.java
@@ -65,7 +65,7 @@ public class DynoJedis implements NdBenchClient {
             public Collection<Host> getHosts() {
 
                 List<Host> hosts = new ArrayList<Host>();
-                hosts.add(new Host("localhost", 8102, Host.Status.Up).setRack("local-dc"));
+                hosts.add(new Host("localhost", 8102, "local-dc", Host.Status.Up));
 
                 return hosts;
             }

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.ndbench.plugin.dyno;
 
 import java.util.ArrayList;

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
@@ -50,7 +50,7 @@ public class DynoJedisExtFunc extends NdBenchBaseClient {
     public String readSingle(String key) throws Exception {
         StringBuilder sb = new StringBuilder();
         String correct = null;
-        JedisUtils jedisUtils = new JedisUtils(jedisClient);
+        DynoJedisUtils jedisUtils = new DynoJedisUtils(jedisClient);
 
         correct = jedisUtils.nonPipelineRead(key);
         if (correct == null)
@@ -83,7 +83,7 @@ public class DynoJedisExtFunc extends NdBenchBaseClient {
     public String writeSingle(String key) throws Exception {
         StringBuilder sb = new StringBuilder();
         String correct = null;
-        JedisUtils jedisUtils = new JedisUtils(jedisClient);
+        DynoJedisUtils jedisUtils = new DynoJedisUtils(jedisClient);
 
         correct = jedisUtils.nonpipelineWrite(key, dataGenerator);
         if (correct == null) {

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
@@ -156,7 +156,7 @@ public class DynoJedisExtFunc extends NdBenchBaseClient {
             public Collection<Host> getHosts() {
 
                 List<Host> hosts = new ArrayList<Host>();
-                hosts.add(new Host("localhost", 8102, Host.Status.Up).setRack("local-dc"));
+                hosts.add(new Host("localhost", 8102, "local-dc",Host.Status.Up));
 
                 return hosts;
             }

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
@@ -1,0 +1,163 @@
+package com.netflix.ndbench.plugin.dyno;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Singleton;
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.jedis.DynoJedisClient;
+import com.netflix.ndbench.api.plugin.DataGenerator;
+import com.netflix.ndbench.api.plugin.NdBenchBaseClient;
+import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
+
+/**
+ * This is the extended functional test for Dynomite.
+ * 
+ * It tests:
+ * 
+ * 1. GET 2. pipelined GET 3. pipelined HGETALL 4. ZRANGE
+ * 
+ * 1. SET 2. pipelined SET 3. pipelined HMSET, 4. ZADD
+ * 
+ * @author ipapapa
+ *
+ */
+
+@Singleton
+@NdBenchClientPlugin("DynoExtFunc")
+public class DynoJedisExtFunc extends NdBenchBaseClient {
+    private final Logger logger = LoggerFactory.getLogger(DynoJedisExtFunc.class);
+
+    private static final int MIN_PIPE_KEYS = 3;
+    private static final int MAX_PIPE_KEYS = 10;
+    private static final int MAX_SCORE = 5;
+    private static final String HM_KEY_PREFIX = "HM__";
+    private static final String Z_KEY_PREFIX = "Z__";
+
+    private static final String ClusterName = "dynomite_redis";
+
+    private DataGenerator dataGenerator;
+
+    private AtomicReference<DynoJedisClient> jedisClient = new AtomicReference<DynoJedisClient>(null);
+
+    @Override
+    public String readSingle(String key) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        String correct = null;
+        JedisUtils jedisUtils = new JedisUtils(jedisClient);
+
+        correct = jedisUtils.nonPipelineRead(key);
+        if (correct == null)
+            return null;
+
+        sb.append("simple get: " + correct + " , ");
+
+        correct = jedisUtils.pipelineRead(key, MAX_PIPE_KEYS, MIN_PIPE_KEYS);
+        if (correct == null)
+            return null;
+
+        sb.append("pipeline get: " + correct + " , ");
+
+        correct = jedisUtils.pipelineReadHGETALL(key, HM_KEY_PREFIX);
+        if (correct == null)
+            return null;
+
+        sb.append("pipeline hash: " + correct + " , ");
+
+        correct = jedisUtils.nonPipelineZRANGE(key, MAX_SCORE);
+        if (correct == null)
+            return null;
+
+        sb.append("sorted set: " + correct + " , ");
+
+        return sb.toString();
+    }
+
+    @Override
+    public String writeSingle(String key) throws Exception {
+        StringBuilder sb = new StringBuilder();
+        String correct = null;
+        JedisUtils jedisUtils = new JedisUtils(jedisClient);
+
+        correct = jedisUtils.nonpipelineWrite(key, dataGenerator);
+        if (correct == null) {
+            return null;
+        }
+        sb.append("simple get: " + correct + " , ");
+
+        correct = jedisUtils.pipelineWrite(key, dataGenerator, MAX_PIPE_KEYS, MIN_PIPE_KEYS);
+        if (correct == null)
+            return null;
+
+        sb.append("pipeline set: " + correct + " , ");
+
+        correct = jedisUtils.pipelineWriteHMSET(key, dataGenerator, HM_KEY_PREFIX);
+        if (correct == null)
+            return null;
+
+        sb.append("pipeline HMSET: " + correct + " , ");
+
+        correct = jedisUtils.nonPipelineZADD(key, dataGenerator, Z_KEY_PREFIX, MAX_SCORE);
+        if (correct == null)
+            return null;
+
+        sb.append("non pipeline ZADD: " + correct + " , ");
+        return sb.toString();
+    }
+
+    @Override
+    public void shutdown() throws Exception {
+        if (jedisClient.get() != null) {
+            jedisClient.get().stopClient();
+            jedisClient.set(null);
+        }
+    }
+
+    @Override
+    public String getConnectionInfo() throws Exception {
+        return String.format("Cluster Name - %s", ClusterName);
+    }
+
+    @Override
+    public void init(DataGenerator dataGenerator) throws Exception {
+        this.dataGenerator = dataGenerator;
+        if (jedisClient.get() != null) {
+            return;
+        }
+
+        logger.info("Initing dyno jedis client");
+
+        logger.info("\nDynomite Cluster: " + ClusterName);
+
+        HostSupplier hSupplier = new HostSupplier() {
+
+            @Override
+            public Collection<Host> getHosts() {
+
+                List<Host> hosts = new ArrayList<Host>();
+                hosts.add(new Host("localhost", 8102, Host.Status.Up).setRack("local-dc"));
+
+                return hosts;
+            }
+
+        };
+
+        DynoJedisClient jClient = new DynoJedisClient.Builder().withApplicationName(ClusterName)
+                .withDynomiteClusterName(ClusterName).withHostSupplier(hSupplier).build();
+
+        jedisClient.set(jClient);
+
+    }
+    
+    @Override
+    public String runWorkFlow() throws Exception {
+        return null;
+    }
+
+}

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisGetSetPipeline.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisGetSetPipeline.java
@@ -4,22 +4,24 @@ import com.google.inject.Singleton;
 import com.netflix.dyno.connectionpool.Host;
 import com.netflix.dyno.connectionpool.HostSupplier;
 import com.netflix.dyno.jedis.DynoJedisClient;
-import com.netflix.dyno.jedis.DynoJedisPipeline;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
 
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.Response;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * This pluging performs GET/SET inside a pipeline of size MAX_PIPE_KEYS against
+ * Dynomite.
+ * 
+ * @author ipapapa
+ *
+ */
 @Singleton
 @NdBenchClientPlugin("DynoGetSetPipeline")
 public class DynoJedisGetSetPipeline implements NdBenchClient {
@@ -33,8 +35,19 @@ public class DynoJedisGetSetPipeline implements NdBenchClient {
     private final AtomicReference<DynoJedisClient> jedisClient = new AtomicReference<DynoJedisClient>(null);
 
     private DataGenerator dataGenerator;
-    private Random randomGenerator = new Random();
 
+    @Override
+    public void shutdown() throws Exception {
+        if (jedisClient.get() != null) {
+            jedisClient.get().stopClient();
+            jedisClient.set(null);
+        }
+    }
+
+    @Override
+    public String getConnectionInfo() throws Exception {
+        return String.format("Cluster Name - %s", ClusterName);
+    }
 
     @Override
     public void init(DataGenerator dataGenerator) throws Exception {
@@ -68,103 +81,20 @@ public class DynoJedisGetSetPipeline implements NdBenchClient {
     }
 
     @Override
-    public String readSingle(String key) throws Exception {
-
-        int pipe_keys = randomGenerator.nextInt(MAX_PIPE_KEYS);
-        pipe_keys = Math.max(MIN_PIPE_KEYS, pipe_keys);
-
-        DynoJedisPipeline pipeline = jedisClient.get().pipelined();
-
-        Map<String, Response<String>> responses = new HashMap<String, Response<String>>();
-        // initialize those many keys
-        for (int n = 0; n < pipe_keys; ++n) {
-            String nth_key = key + "_" + n;
-            // NOTE: Dyno Jedis works on only one key, so we always use the same
-            // key in every get operation
-            Response<String> resp = pipeline.get(key);
-            // We however use the nth key as the key in the hashmap to check
-            // individual response on every operation.
-            responses.put(nth_key, resp);
-        }
-        pipeline.sync();
-
-        for (int n = 0; n < pipe_keys; ++n) {
-            String nth_key = key + "_" + n;
-            Response<String> resp = responses.get(nth_key);
-            if (resp == null || resp.get() == null) {
-                logger.info("Cache Miss: key:" + key);
-                return null;
-            } else {
-                if (resp.get().startsWith("ERR")) {
-                    throw new Exception(String.format("DynoJedisPipeline: error %s", resp.get()));
-                }
-
-                if (!isValidResponse(key, resp.get())) {
-                    throw new Exception(String.format(
-                            "DynoJedisPipeline: pipeline read: value %s does not contain key %s", resp.get(), key));
-                }
-
-            }
-        }
-        return "OK";
+    public String runWorkFlow() throws Exception {
+        return null;
     }
 
-    private boolean isValidResponse(String key, String value) {
-        return value.startsWith(key) && value.endsWith(key);
+    @Override
+    public String readSingle(String key) throws Exception {
+        DynoJedisUtils jedisUtils = new DynoJedisUtils(jedisClient);
+        return jedisUtils.pipelineRead(key, MAX_PIPE_KEYS, MIN_PIPE_KEYS);
     }
 
     @Override
     public String writeSingle(String key) throws Exception {
-        // Create a random key between [0,MAX_PIPE_KEYS]
-        int pipe_keys = randomGenerator.nextInt(MAX_PIPE_KEYS);
-
-        // Make sure that the number of keys in the pipeline are at least
-        // MIN_PIPE_KEYS
-        pipe_keys = Math.max(MIN_PIPE_KEYS, pipe_keys);
-
-        DynoJedisPipeline pipeline = jedisClient.get().pipelined();
-        Map<String, Response<String>> responses = new HashMap<String, Response<String>>();
-
-        /**
-         * writeSingle returns a single string, so we want to create a
-         * StringBuilder to append all the keys in the form "key_n". This is
-         * just used to return a single string
-         */
-        StringBuilder sb = new StringBuilder();
-        // Iterate across the number of keys in the pipeline and set
-        for (int n = 0; n < pipe_keys; ++n) {
-            String nth_key = key + "_" + n;
-            sb.append(nth_key);
-            Response<String> resp = pipeline.set(key, key + this.dataGenerator.getRandomValue() + key);
-            responses.put(nth_key, resp);
-        }
-        pipeline.sync();
-
-        return sb.toString();
-    }
-
-    /**
-     * Shutdown the client
-     */
-    @Override
-    public void shutdown() throws Exception {
-        if (jedisClient.get() != null) {
-            jedisClient.get().stopClient();
-            jedisClient.set(null);
-        }
-    }
-
-    /**
-     * Get connection information
-     */
-    @Override
-    public String getConnectionInfo() throws Exception {
-        return String.format("DynoJedis Plugin - ConnectionInfo ::Cluster Name - %s", ClusterName);
-    }
-
-    @Override
-    public String runWorkFlow() throws Exception {
-        return null;
+        DynoJedisUtils jedisUtils = new DynoJedisUtils(jedisClient);
+        return jedisUtils.pipelineWrite(key, dataGenerator, MAX_PIPE_KEYS, MIN_PIPE_KEYS);
     }
 
 }

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisGetSetPipeline.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisGetSetPipeline.java
@@ -81,7 +81,7 @@ public class DynoJedisGetSetPipeline implements NdBenchClient {
             public Collection<Host> getHosts() {
 
                 List<Host> hosts = new ArrayList<Host>();
-                hosts.add(new Host("localhost", 8102, Host.Status.Up).setRack("local-dc"));
+                hosts.add(new Host("localhost", 8102, "local-dc", Host.Status.Up));
 
                 return hosts;
             }

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisGetSetPipeline.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisGetSetPipeline.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.ndbench.plugin.dyno;
 
 import com.google.inject.Singleton;

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisHashPipeline.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisHashPipeline.java
@@ -68,7 +68,7 @@ public class DynoJedisHashPipeline implements NdBenchClient {
             public Collection<Host> getHosts() {
 
                 List<Host> hosts = new ArrayList<Host>();
-                hosts.add(new Host("localhost", 8102, Host.Status.Up).setRack("local-dc"));
+                hosts.add(new Host("localhost", 8102, "local-dc", Host.Status.Up));
 
                 return hosts;
             }

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisHashPipeline.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisHashPipeline.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.ndbench.plugin.dyno;
 
 import com.google.inject.Singleton;

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisUtils.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.ndbench.plugin.dyno;
 
 import java.util.HashMap;

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisUtils.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisUtils.java
@@ -16,17 +16,17 @@ import com.netflix.ndbench.api.plugin.DataGenerator;
 
 import redis.clients.jedis.Response;
 
-public class JedisUtils {
+public class DynoJedisUtils {
     // private final AtomicReference<DynoJedisClient> jedisClient = new
     // AtomicReference<DynoJedisClient>(null);
     private AtomicReference<DynoJedisClient> jedisClient;
     private static final String ResultOK = "Ok";
     private static final String CacheMiss = null;
 
-    private final static Logger logger = LoggerFactory.getLogger(JedisUtils.class);
+    private final static Logger logger = LoggerFactory.getLogger(DynoJedisUtils.class);
     private static Random randomGenerator = new Random();
 
-    public JedisUtils(AtomicReference<DynoJedisClient> jedisClient) {
+    public DynoJedisUtils(AtomicReference<DynoJedisClient> jedisClient) {
         this.jedisClient = jedisClient;
     }
 

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/JedisUtils.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/JedisUtils.java
@@ -1,0 +1,253 @@
+package com.netflix.ndbench.plugin.dyno;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.dyno.jedis.DynoJedisClient;
+import com.netflix.dyno.jedis.DynoJedisPipeline;
+import com.netflix.ndbench.api.plugin.DataGenerator;
+
+import redis.clients.jedis.Response;
+
+public class JedisUtils {
+    // private final AtomicReference<DynoJedisClient> jedisClient = new
+    // AtomicReference<DynoJedisClient>(null);
+    private AtomicReference<DynoJedisClient> jedisClient;
+    private static final String ResultOK = "Ok";
+    private static final String CacheMiss = null;
+
+    private final static Logger logger = LoggerFactory.getLogger(JedisUtils.class);
+    private static Random randomGenerator = new Random();
+
+    public JedisUtils(AtomicReference<DynoJedisClient> jedisClient) {
+        this.jedisClient = jedisClient;
+    }
+
+    /**
+     * This is the non pipelined version of the reads
+     * 
+     * @param key
+     * @return the value of the corresponding key
+     * @throws Exception
+     */
+    public String nonPipelineRead(String key) throws Exception {
+
+        String res = jedisClient.get().get(key);
+
+        if (res != null) {
+            if (res.isEmpty()) {
+                throw new Exception("Data retrieved is not ok ");
+            }
+        } else {
+            return CacheMiss;
+        }
+
+        return ResultOK;
+
+    }
+
+    /**
+     * This is the pipelined version of the reads
+     * 
+     * @param key
+     * @return "OK" if everything was read
+     * @throws Exception
+     */
+    public String pipelineRead(String key, int max_pipe_keys, int min_pipe_keys) throws Exception {
+        int pipe_keys = randomGenerator.nextInt(max_pipe_keys);
+        pipe_keys = Math.max(min_pipe_keys, pipe_keys);
+
+        DynoJedisPipeline pipeline = this.jedisClient.get().pipelined();
+
+        Map<String, Response<String>> responses = new HashMap<String, Response<String>>();
+        for (int n = 0; n < pipe_keys; ++n) {
+            String nth_key = key + "_" + n;
+            // NOTE: Dyno Jedis works on only one key, so we always use the same
+            // key in every get operation
+            Response<String> resp = pipeline.get(key);
+            // We however use the nth key as the key in the hashmap to check
+            // individual response on every operation.
+            responses.put(nth_key, resp);
+        }
+        pipeline.sync();
+
+        for (int n = 0; n < pipe_keys; ++n) {
+            String nth_key = key + "_" + n;
+            Response<String> resp = responses.get(nth_key);
+            if (resp == null || resp.get() == null) {
+                logger.info("Cache Miss on pipelined read: key:" + key);
+                return null;
+            } else {
+                if (resp.get().startsWith("ERR")) {
+                    throw new Exception(String.format("DynoJedisPipeline: error %s", resp.get()));
+                }
+
+                if (!isValidResponse(key, resp.get())) {
+                    throw new Exception(String.format(
+                            "DynoJedisPipeline: pipeline read: value %s does not contain key %s", resp.get(), key));
+
+                }
+
+            }
+        }
+        return "OK";
+    }
+
+    /**
+     * This the pipelined HGETALL
+     * 
+     * @param key
+     * @return the contents of the hash
+     * @throws Exception
+     */
+    public String pipelineReadHGETALL(String key, String hm_key_prefix) throws Exception {
+        DynoJedisPipeline pipeline = jedisClient.get().pipelined();
+        Response<Map<byte[], byte[]>> resp = pipeline.hgetAll((hm_key_prefix + key).getBytes());
+        pipeline.sync();
+        if (resp == null || resp.get() == null) {
+            logger.info("Cache Miss: key:" + key);
+            return null;
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (byte[] bytes : resp.get().keySet()) {
+                if (sb.length() > 0) {
+                    sb.append(",");
+                }
+                sb.append(new String(bytes));
+            }
+            return "HGETALL:" + sb.toString();
+        }
+    }
+
+    /**
+     * Exercising ZRANGE to receive all keys between 0 and MAX_SCORE
+     * 
+     * @param key
+     */
+    public String nonPipelineZRANGE(String key, int max_score) {
+        StringBuilder sb = new StringBuilder();
+        // Return all elements
+        Set<String> returnEntries = this.jedisClient.get().zrange(key, 0, -1);
+        if (returnEntries.isEmpty()) {
+            logger.error("The number of entries in the sorted set are less than the number of entries written");
+            return null;
+        }
+
+        for (Iterator<String> it = returnEntries.iterator(); it.hasNext();) {
+            String f = it.next();
+            sb.append(f);
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * a simple write without a pipeline
+     * 
+     * @param key
+     * @return the result of write (i.e. "OK" if it was successful
+     */
+    public String nonpipelineWrite(String key, DataGenerator dataGenerator) {
+        String value = key + "__" + dataGenerator.getRandomValue() + "__" + key;
+        String result = this.jedisClient.get().set(key, value);
+
+        if (!"OK".equals(result)) {
+            logger.error("SET_ERROR: GOT " + result + " for SET operation");
+            throw new RuntimeException(String.format("DynoJedis: value %s for SET operation is NOT VALID", value, key));
+
+        }
+
+        return result;
+    }
+
+    /**
+     * pipelined version of the write
+     * 
+     * @param key
+     * @return "key_n"
+     */
+    public String pipelineWrite(String key, DataGenerator dataGenerator, int max_pipe_keys, int min_pipe_keys)
+            throws Exception {
+        // Create a random key between [0,MAX_PIPE_KEYS]
+        int pipe_keys = randomGenerator.nextInt(max_pipe_keys);
+
+        // Make sure that the number of keys in the pipeline are at least
+        // MIN_PIPE_KEYS
+        pipe_keys = Math.max(min_pipe_keys, pipe_keys);
+
+        DynoJedisPipeline pipeline = this.jedisClient.get().pipelined();
+        Map<String, Response<String>> responses = new HashMap<String, Response<String>>();
+
+        /**
+         * writeSingle returns a single string, so we want to create a
+         * StringBuilder to append all the keys in the form "key_n". This is
+         * just used to return a single string
+         */
+        StringBuilder sb = new StringBuilder();
+        // Iterate across the number of keys in the pipeline and set
+        for (int n = 0; n < pipe_keys; ++n) {
+            String nth_key = key + "_" + n;
+            sb.append(nth_key);
+            Response<String> resp = pipeline.set(key, key + dataGenerator.getRandomValue() + key);
+            responses.put(nth_key, resp);
+        }
+        pipeline.sync();
+
+        return sb.toString();
+    }
+
+    /**
+     * writes with an pipelined HMSET
+     * 
+     * @param key
+     * @return the keys of the hash that was stored.
+     */
+    public String pipelineWriteHMSET(String key, DataGenerator dataGenerator, String hm_key_prefix) {
+        Map<String, String> map = new HashMap<String, String>();
+        String hmKey = hm_key_prefix + key;
+        map.put((hmKey + "__1"), (key + "__" + dataGenerator.getRandomValue() + "__" + key));
+        map.put((hmKey + "__2"), (key + "__" + dataGenerator.getRandomValue() + "__" + key));
+
+        DynoJedisPipeline pipeline = jedisClient.get().pipelined();
+        pipeline.hmset(hmKey, map);
+        pipeline.expire(hmKey, 3600);
+        pipeline.sync();
+
+        return "HMSET:" + hmKey;
+    }
+
+    /**
+     * This adds MAX_SCORE of elements in a sorted set
+     * 
+     * @param key
+     * @return "OK" if all write operations have succeeded
+     * @throws Exception
+     */
+    public String nonPipelineZADD(String key, DataGenerator dataGenerator, String z_key_prefix, int max_score)
+            throws Exception {
+
+        String zKey = z_key_prefix + key;
+        int success = 0;
+        long returnOp = 0;
+        for (int i = 0; i < max_score; i++) {
+            returnOp = jedisClient.get().zadd(zKey, i, dataGenerator.getRandomValue() + "__" + zKey);
+            success += returnOp;
+        }
+        // all the above operations will seperate entries
+        if (success != max_score - 1) {
+            return null;
+        }
+        return "OK";
+    }
+
+    private static boolean isValidResponse(String key, String value) {
+        return value.startsWith(key) && value.endsWith(key);
+    }
+}

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/local/dynomite/proxy/LocalDynomiteProxyPlugin.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/local/dynomite/proxy/LocalDynomiteProxyPlugin.java
@@ -46,7 +46,7 @@ public class LocalDynomiteProxyPlugin implements NdBenchClient{
     private static final String ResultOK = "Ok";
     private static final String CacheMiss = null;
 
-    private static final String ClusterName = "dynomite_redis_puneet";
+    private static final String ClusterName = "dynomite_redis";
 
     private DataGenerator dataGenerator;
 
@@ -71,7 +71,7 @@ public class LocalDynomiteProxyPlugin implements NdBenchClient{
             public Collection<Host> getHosts() {
 
                 List<Host> hosts = new ArrayList<Host>();
-                hosts.add(new Host("localhost", 8102, Host.Status.Up).setRack("local-dc"));
+                hosts.add(new Host("localhost", 8102, "local-dc", Host.Status.Up));
 
                 return hosts;
             }

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/local/dynomite/proxy/LocalDynomiteProxyPlugin.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/local/dynomite/proxy/LocalDynomiteProxyPlugin.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.ndbench.plugin.local.dynomite.proxy;
 
 import java.util.ArrayList;

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/local/dynomite/proxy/LocalHttpEndpointBasedTokenMapSupplier.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/local/dynomite/proxy/LocalHttpEndpointBasedTokenMapSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.ndbench.plugin.local.dynomite.proxy;
 
 import com.netflix.dyno.connectionpool.impl.lb.HttpEndpointBasedTokenMapSupplier;


### PR DESCRIPTION
* Add a new class that can be used for Functional Testing of several Redis commands such as `GET`/`SET`, pipelines, `HGETALL`/`HMSET`, `ZADD`/`ZRANGE`.
* It centralizes the JedisUtils so they can be used across all Dyno plugins without having to change the core code of each plugin.
* Added proper Javadoc for the Dynomite plugins.
* Updated dyno library to use the latest release.
