### PR TITLE
Fix batch consistency level bug

### DIFF
--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverGeneric.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverGeneric.java
@@ -52,15 +52,15 @@ public class CassJavaDriverGeneric extends CJavaDriverBasePlugin {
 
     @Override
     public String writeSingle(String key) throws Exception {
-        BatchStatement batch = new BatchStatement();
+        BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
         for (int i = 0; i < this.MaxColCount; i++) {
             BoundStatement bStmt = writePstmt.bind();
             bStmt.setString("key", key);
             bStmt.setInt("column1", i);
             bStmt.setString("value", this.dataGenerator.getRandomValue());
-            bStmt.setConsistencyLevel(this.WriteConsistencyLevel);
             batch.add(bStmt);
         }
+	batch.setConsistencyLevel(this.WriteConsistencyLevel);
         session.execute(batch);
         batch.clear();
         return ResultOK;


### PR DESCRIPTION
Here is the pull request you asked me to create for the batch consistency level bug. setConsistencyLevel needed to be moved from individual statements to the overall batch statement. Note that I also changed the constructor for the batch statement to explicitly specify unlogged batch.  This shouldn't affect anything since Cassandra should not log batches directed to a single partition key anyway, but I thought it was better to be explicit.