### PR TITLE
api and driver support for auto-tuning write operations during benchmark run

### DIFF
--- a/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/NdBenchAbstractClient.java
+++ b/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/NdBenchAbstractClient.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.ndbench.api.plugin;
+
+/**
+ * Defines default methods that provide a hook point for Auto-tuning.
+ *
+ * Auto-tuning is a process which automates the task of adjusting read/write rate limits right up to the point
+ * where performance starts to fall below a configurable threshold. In a nutshell, the technique involves
+ * (1) setting the initial read/write limit for your benchmark run to a low enough level that is guaranteed
+ * not to overload the data store  you are benchmarking,  and then (2) providing implementations for  the
+ * autoTune[Write/Read]RateLimit methods which will first examine  events which encode the results of read/write
+ * operations together with  run time statistics, and the currentRateLimit. After interpretting  these
+ * two pieces of information the process will return a new recommended rate limit (which may be higher or
+ * lower than currentRateLimit.)
+ *
+ * This interfaces provide backward compatability with legacy client plug-ins  (which do not support auto-tuning)
+ * since the interface {@link  com.netflix.ndbench.api.plugin.NdBenchClient} concretizes the type parameter 'W'
+ * to the type that heretofore has been returned by all clients implementing the writeSingle method (namely: String.)
+ *
+ * @param <W>  - the type of the result returned by {@link #writeSingle}
+ *
+ */
+ public interface NdBenchAbstractClient<W> {
+
+	/**
+	 * Initialize the client
+	 * @throws Exception
+	 */
+	 void init(DataGenerator dataGenerator) throws Exception;
+	
+	/**
+	 * Perform a single read operation
+	 * @return
+	 * @throws Exception
+	 */
+	 String readSingle(final String key) throws Exception;
+
+
+	/**
+	 * Perform a single write operation
+	 * @return
+	 * @throws Exception
+	 */
+	 W writeSingle(final String key) throws Exception;
+
+
+    /**
+     * shutdown the client
+     */
+     void shutdown() throws Exception;
+
+    /**
+     * Get connection info
+     */
+     String getConnectionInfo() throws Exception;
+
+    /**
+     * Run workflow for functional testing
+     * @throws Exception
+     */
+     String runWorkFlow() throws Exception;
+
+	/**
+	 * Implementations of the  autoTune[Write/Read]RateLimit methods will interpret the information provided by
+	 * 'event' and 'runStats' in order to determine whether or not it is appropriate to auto-tune
+	 * read / write rate limits for the currently running benchmark.
+	 *
+	 * This method will be called by the benchmark driver after every write operation (this applies
+	 * to the initial implementation -- subsequent releases may also allow tuning based on responses to read operations).
+     *
+	 * Note that if there are multiple read or write workers it is possible that an attempt by one thread to auto-tune
+	 * the rate limit to a particular level might be overwritten by the rate limit value set by another thread. But
+	 * in the case performance degradation or errors occur, the eventual trend of the rate limit should be downward.
+	 *
+     *
+	 * @param currentRateLimit - the write rate limit currently in effect.
+	 *
+	 * @param event - conveys information related to the most recently performed read or write operation which
+	 *                this method will use to decide  whether or not it is appropriate to auto-tune
+	 *                 write / read rate limits for the currently running benchmark. An event will typically
+	 *                 capture details of errors occurring in the context of  an attempt to perform
+	 *                 either a read or write operation.
+     *
+	 * @param runStats - statistics such as average write/read latency for current benchmark run
+	 *
+	 * @return - the new suggested rate limit -- ignored by driver if <= 0.
+	 */
+
+	default double autoTuneWriteRateLimit(double currentRateLimit, W event,  NdBenchMonitor runStats) { return -1D;}
+
+	/**
+	 * See documentation for {@link #autoTuneWriteRateLimit}
+	 */
+	default double autoTuneReadRateLimit(double currentRateLimit, W event,  NdBenchMonitor runStats) {
+		throw new UnsupportedOperationException("not yet implemented");
+	}
+}

--- a/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/NdBenchClient.java
+++ b/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/NdBenchClient.java
@@ -20,7 +20,7 @@ package com.netflix.ndbench.api.plugin;
 /**
  * @author vchella
  */
- public interface NdBenchClient {
+ public interface NdBenchClient extends NdBenchAbstractClient<String> {
 
 	/**
 	 * Initialize the client

--- a/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/NdBenchMonitor.java
+++ b/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/NdBenchMonitor.java
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  */
-package com.netflix.ndbench.core.monitoring;
+package com.netflix.ndbench.api.plugin;
 
 /**
  * Monitoring interface to receive notification of NdBench events. A concrete

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverManagerImpl.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverManagerImpl.java
@@ -5,7 +5,6 @@ package com.netflix.ndbench.plugin.cass;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
-import com.netflix.ndbench.plugin.cass.CassJavaDriverManager;
 
 /**
  * @author vchella

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverPlugin.java
@@ -17,8 +17,6 @@
 package com.netflix.ndbench.plugin.cass;
 
 import com.datastax.driver.core.*;
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.Row;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.archaius.api.PropertyFactory;

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/elassandra/ElassandraCassJavaDriverPlugin.java
@@ -15,24 +15,17 @@
  */
 package com.netflix.ndbench.plugin.elassandra;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Session;
+import com.datastax.driver.core.*;
 import com.google.inject.Singleton;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
 import com.netflix.ndbench.plugin.cass.CassJavaDriverPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This is a Elassandra(http://www.elassandra.io/) plugin using the CASS api. <BR> 

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/NdBenchDriver.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/NdBenchDriver.java
@@ -22,10 +22,10 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
+import com.netflix.ndbench.api.plugin.NdBenchMonitor;
 import com.netflix.ndbench.core.config.IConfiguration;
 import com.netflix.ndbench.core.generators.KeyGenerator;
 import com.netflix.ndbench.core.generators.KeyGeneratorFactory;
-import com.netflix.ndbench.core.monitoring.NdBenchMonitor;
 import com.netflix.ndbench.core.operations.ReadOperation;
 import com.netflix.ndbench.core.operations.WriteOperation;
 import com.netflix.ndbench.core.util.LoadPattern;
@@ -131,13 +131,15 @@ public class NdBenchDriver {
 
         keyGeneratorReadRef.set(keyGenerator);
 
-        startOperation(config.isReadEnabled(),
+        startOperation(
+                config.isReadEnabled(),
                 config.getNumReaders(),
                 readWorkers,
                 tpReadRef,
                 readLimiter,
                 operation,
-                keyGenerator);
+                keyGenerator,
+                config.isAutoTuneEnabled());
         readsStarted.set(true);
     }
 
@@ -169,7 +171,8 @@ public class NdBenchDriver {
                 tpWriteRef,
                 writeLimiter,
                 operation,
-                keyGenerator);
+                keyGenerator,
+                config.isAutoTuneEnabled());
 
         writesStarted.set(true);
     }
@@ -191,8 +194,9 @@ public class NdBenchDriver {
                                 AtomicInteger numWorkers,
                                 AtomicReference<ExecutorService> tpRef,
                                 final AtomicReference<RateLimiter> rateLimiter,
-                                final NdBenchOperation operation
-                                , final KeyGenerator<String> keyGenerator) {
+                                final NdBenchOperation operation,
+                                final KeyGenerator<String> keyGenerator,
+                                Boolean isAutoTuneEnabled) {
 
         if (!operationEnabled) {
             Logger.info("Operation : " + operation.getClass().getSimpleName() + " not enabled, ignoring");
@@ -218,7 +222,8 @@ public class NdBenchDriver {
                         if ((operation.isReadType() && readsStarted.get()) ||
                                 (operation.isWriteType() && writesStarted.get())) {
                             if (rateLimiter.get().tryAcquire()) {
-                                operation.process(ndBenchMonitor, keyGenerator.getNextKey());
+                                operation.process(
+                                        ndBenchMonitor, keyGenerator.getNextKey(), rateLimiter, isAutoTuneEnabled);
                             }
                         }
                         if (!keyGenerator.hasNextKey())
@@ -304,7 +309,10 @@ public class NdBenchDriver {
     }
 
     public interface NdBenchOperation {
-        boolean process(NdBenchMonitor monitor, String key);
+        boolean process(NdBenchMonitor monitor,
+                        String key,
+                        AtomicReference<RateLimiter> rateLimiter,
+                        boolean isAutoTuneEnabled);
 
         boolean isReadType();
 

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
@@ -92,4 +92,8 @@ public interface IConfiguration {
     @DefaultValue("100")
     int getWriteRateLimit();
 
+
+    @DefaultValue("false")
+    Boolean isAutoTuneEnabled();
+
 }

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
@@ -16,22 +16,19 @@
  */
 package com.netflix.ndbench.core.defaultimpl;
 
+import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
-import com.netflix.ndbench.core.config.NdbenchConfigListener;
-import org.slf4j.LoggerFactory;
-
-import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.MapBinder;
 import com.netflix.ndbench.api.plugin.DataGenerator;
-import com.netflix.ndbench.api.plugin.NdBenchClient;
+import com.netflix.ndbench.api.plugin.NdBenchMonitor;
 import com.netflix.ndbench.core.config.IConfiguration;
-//import com.netflix.ndbench.core.config.NdBenchConfiguration;
+import com.netflix.ndbench.core.config.NdbenchConfigListener;
 import com.netflix.ndbench.core.discovery.IClusterDiscovery;
 import com.netflix.ndbench.core.discovery.LocalClusterDiscovery;
 import com.netflix.ndbench.core.generators.DefaultDataGenerator;
 import com.netflix.ndbench.core.monitoring.FakeMonitor;
-import com.netflix.ndbench.core.monitoring.NdBenchMonitor;
+
+//import com.netflix.ndbench.core.config.NdBenchConfiguration;
 
 /**
  * @author vchella

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AWSLocalClusterDiscovery.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AWSLocalClusterDiscovery.java
@@ -15,6 +15,9 @@
  */
 package com.netflix.ndbench.core.discovery;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -22,9 +25,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class does Cluster discovery at AWS VPC cloud env. <BR>

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/LocalClusterDiscovery.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/LocalClusterDiscovery.java
@@ -20,8 +20,6 @@ package com.netflix.ndbench.core.discovery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/monitoring/FakeMonitor.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/monitoring/FakeMonitor.java
@@ -18,6 +18,7 @@ package com.netflix.ndbench.core.monitoring;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.netflix.ndbench.api.plugin.NdBenchMonitor;
 import com.netflix.ndbench.core.config.IConfiguration;
 import com.netflix.ndbench.core.util.EstimatedHistogram;
 import org.slf4j.LoggerFactory;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/operations/ReadOperation.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/operations/ReadOperation.java
@@ -17,11 +17,14 @@
 
 package com.netflix.ndbench.core.operations;
 
+import com.google.common.util.concurrent.RateLimiter;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
+import com.netflix.ndbench.api.plugin.NdBenchMonitor;
 import com.netflix.ndbench.core.NdBenchDriver;
-import com.netflix.ndbench.core.monitoring.NdBenchMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author vchella
@@ -36,7 +39,10 @@ public class ReadOperation implements NdBenchDriver.NdBenchOperation {
     }
 
     @Override
-    public boolean process(NdBenchMonitor monitor,  String key) {
+    public boolean process(NdBenchMonitor monitor,
+                           String key,
+                           AtomicReference<RateLimiter> ignoredForNow,
+                           boolean isAutoTuneEnabled) {
         try {
             Long startTime = System.nanoTime();
             String value = client.readSingle(key);

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/resources/NdBenchResource.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/resources/NdBenchResource.java
@@ -19,13 +19,13 @@ package com.netflix.ndbench.core.resources;
 
 import com.google.inject.Inject;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
+import com.netflix.ndbench.api.plugin.NdBenchMonitor;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
 import com.netflix.ndbench.core.DataBackfill;
 import com.netflix.ndbench.core.NdBenchClientFactory;
 import com.netflix.ndbench.core.NdBenchDriver;
 import com.netflix.ndbench.core.config.IConfiguration;
 import com.netflix.ndbench.core.generators.KeyGenerator;
-import com.netflix.ndbench.core.monitoring.NdBenchMonitor;
 import com.netflix.ndbench.core.util.LoadPattern;
 import com.sun.jersey.multipart.FormDataParam;
 import groovy.lang.GroovyClassLoader;

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisExtFunc.java
@@ -15,14 +15,6 @@
  */
 package com.netflix.ndbench.plugin.dyno;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.Singleton;
 import com.netflix.dyno.connectionpool.Host;
 import com.netflix.dyno.connectionpool.HostSupplier;
@@ -30,6 +22,13 @@ import com.netflix.dyno.jedis.DynoJedisClient;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchBaseClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * This is the extended functional test for Dynomite.

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisGetSetPipeline.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisGetSetPipeline.java
@@ -22,7 +22,6 @@ import com.netflix.dyno.jedis.DynoJedisClient;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
-
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisHashPipeline.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisHashPipeline.java
@@ -22,7 +22,6 @@ import com.netflix.dyno.jedis.DynoJedisClient;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
-
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisUtils.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/dyno/DynoJedisUtils.java
@@ -15,21 +15,15 @@
  */
 package com.netflix.ndbench.plugin.dyno;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.netflix.dyno.jedis.DynoJedisClient;
 import com.netflix.dyno.jedis.DynoJedisPipeline;
 import com.netflix.ndbench.api.plugin.DataGenerator;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Response;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DynoJedisUtils {
     // private final AtomicReference<DynoJedisClient> jedisClient = new

--- a/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/local/dynomite/proxy/LocalDynomiteProxyPlugin.java
+++ b/ndbench-dyno-plugins/src/main/java/com/netflix/ndbench/plugin/local/dynomite/proxy/LocalDynomiteProxyPlugin.java
@@ -15,14 +15,6 @@
  */
 package com.netflix.ndbench.plugin.local.dynomite.proxy;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.Singleton;
 import com.netflix.dyno.connectionpool.ConnectionPoolConfiguration.LoadBalancingStrategy;
 import com.netflix.dyno.connectionpool.Host;
@@ -34,6 +26,13 @@ import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
 import com.netflix.ndbench.plugin.dyno.DynoJedis;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author diegopacheco


### PR DESCRIPTION

pls see documentation in com.netflix.ndbench.api.plugin.NdBenchAbstractClient for more details.

Note: also ran 'optimize imports', some unrelated files were cleaned up in the process.