### PR TITLE
add clarification to title of Instance Statistics dialog [

### DIFF
--- a/ndbench-web/src/main/webapp/elements/ndbench-ui-app.html
+++ b/ndbench-web/src/main/webapp/elements/ndbench-ui-app.html
@@ -21320,7 +21320,6 @@ Custom property | Description | Default
 
         <ndb-card heading="Instance Statistics (per node, not aggregated across client driver instances)">
 
-
             <h4>[[ instance.HostName ]]</h4>
 
             <div id="legend"></div>

--- a/ndbench-web/src/main/webapp/elements/ndbench-ui-app.html
+++ b/ndbench-web/src/main/webapp/elements/ndbench-ui-app.html
@@ -21318,7 +21318,9 @@ Custom property | Description | Default
             }
         </style>
 
-        <ndb-card heading="Instance Statistics">
+        <ndb-card heading="Instance Statistics (per node, not aggregated across client driver instances)">
+
+
             <h4>[[ instance.HostName ]]</h4>
 
             <div id="legend"></div>


### PR DESCRIPTION
 Clarify that Statistics are gathered per node, not aggregated across client driver instances 
   (this confused me when initially trying to interpret the graphs and reports on this panel).

