### PR TITLE
change groovy dependency to fixed version so we don't get  the beta r…

### DIFF
--- a/ndbench-core/build.gradle
+++ b/ndbench-core/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile "org.codehaus.groovy:groovy-all:latest.release"
+    compile "org.codehaus.groovy:groovy-all:2.4.+"
     compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
     compile group: 'joda-time', name: 'joda-time', version: 'latest.release'
 


### PR DESCRIPTION
Here are the full details of why we needed to update the dependency on groovy all: 
>>>
The Groovy project released pre-release dependencies of 2.5.0 to Maven Central/JCenter in the last few days. Teams with a 2.+ or latest.release constraint on these dependencies are introducing them into the dependency graph, causing downstream projects to break.

A resolution rule has been added to reject these versions. For projects with first order dependencies, the rule will ensure that a 2.4.x version is selected. Downstream projects will not be able to resolve these versions, and will fail with:
> Could not find org.codehaus.groovy:groovy-all:2.5.0-beta-1.
Required by:
project :recs-test > netflix:p13nalgo-recs-client-esl:2.116 > netflix:videometadata-client:60.29