### PR TITLE
don't rely on CI env vars to disable docker tests.

### DIFF
--- a/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/EsRestPluginIntegrationTest.java
+++ b/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/EsRestPluginIntegrationTest.java
@@ -58,7 +58,7 @@ public class EsRestPluginIntegrationTest extends AbstractPluginIntegrationTest {
 
     @BeforeClass
     public static void initialize() throws Exception {
-        if (disableIfDockerComposeUnavailable) {
+        if (disableDueToDockerExecutableUnavailability) {
             return;
         }
         if (StringUtils.isNotEmpty(System.getenv("ES_NDBENCH_NO_DOCKER"))) {
@@ -76,7 +76,7 @@ public class EsRestPluginIntegrationTest extends AbstractPluginIntegrationTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        if (disableIfDockerComposeUnavailable) {
+        if (disableDueToDockerExecutableUnavailability) {
             return;
         }
         if (StringUtils.isNotEmpty(System.getenv("ES_NDBENCH_NO_DOCKER"))) {
@@ -88,7 +88,7 @@ public class EsRestPluginIntegrationTest extends AbstractPluginIntegrationTest {
 
     @Test
     public void testCanReadWhatWeJustWrote() throws Exception {
-        if (disableIfDockerComposeUnavailable) {
+        if (disableDueToDockerExecutableUnavailability) {
             return
                     ;
         }


### PR DESCRIPTION
don't rely on CI env vars to disable docker tests.
 just disable if  the executables for docker and docker-compose are unavailable