### PR TITLE
Ditch tmp table for formula

### DIFF
--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/DataBackfill.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/DataBackfill.java
@@ -20,7 +20,6 @@ package com.netflix.ndbench.core;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.ndbench.api.plugin.NdBenchAbstractClient;
-import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.core.config.IConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/NdBenchClientFactory.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/NdBenchClientFactory.java
@@ -20,7 +20,6 @@ package com.netflix.ndbench.core;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.ndbench.api.plugin.NdBenchAbstractClient;
-import com.netflix.ndbench.api.plugin.NdBenchClient;
 
 import java.util.Map;
 import java.util.Set;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchClientModule.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchClientModule.java
@@ -19,12 +19,10 @@ import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import com.netflix.ndbench.api.plugin.NdBenchAbstractClient;
-import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
 import org.reflections.Reflections;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Type;
 import java.util.Set;
 
 public class NdBenchClientModule extends AbstractModule {

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
@@ -16,8 +16,6 @@
  */
 package com.netflix.ndbench.core.defaultimpl;
 
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
@@ -32,8 +30,7 @@ import com.netflix.ndbench.core.discovery.IClusterDiscovery;
 import com.netflix.ndbench.core.discovery.LocalClusterDiscovery;
 import com.netflix.ndbench.core.generators.DefaultDataGenerator;
 import com.netflix.ndbench.core.monitoring.FakeMonitor;
-
-import javax.inject.Singleton;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author vchella

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/generators/DefaultDataGenerator.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/generators/DefaultDataGenerator.java
@@ -18,7 +18,6 @@ package com.netflix.ndbench.core.generators;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.core.config.IConfiguration;
 import org.apache.commons.lang.RandomStringUtils;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/operations/ReadOperation.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/operations/ReadOperation.java
@@ -18,9 +18,7 @@
 package com.netflix.ndbench.core.operations;
 
 import com.google.common.util.concurrent.RateLimiter;
-import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.ndbench.api.plugin.NdBenchAbstractClient;
-import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.NdBenchMonitor;
 import com.netflix.ndbench.core.NdBenchDriver;
 import org.slf4j.Logger;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/operations/WriteOperation.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/operations/WriteOperation.java
@@ -18,7 +18,6 @@
 package com.netflix.ndbench.core.operations;
 
 import com.google.common.util.concurrent.RateLimiter;
-import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.ndbench.api.plugin.NdBenchAbstractClient;
 import com.netflix.ndbench.api.plugin.NdBenchMonitor;
 import com.netflix.ndbench.core.NdBenchDriver;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/util/ConstantStepWiseRateIncreaser.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/util/ConstantStepWiseRateIncreaser.java
@@ -25,17 +25,6 @@ public class ConstantStepWiseRateIncreaser {
     private final int incrementIntervalMillisecs;
     private final double rateIncrementPerStep;
 
-    @Immutable
-    private class Cell {
-        private final long time;
-        private final double rate;
-
-        Cell(long time, double rate) {
-            this.time = time;
-            this.rate = rate;
-        }
-    }
-
 
     /**
      * Returns a step-wise rate increaser which will ramp from 'initRate' to 'finalRate' over the course of

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/util/ConstantStepWiseRateIncreaser.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/util/ConstantStepWiseRateIncreaser.java
@@ -1,9 +1,6 @@
 package com.netflix.ndbench.core.util;
 
-import com.google.common.collect.ImmutableList;
-
 import javax.annotation.concurrent.Immutable;
-import java.util.ArrayList;
 
 /**
  * Ramps a rate from  a specified 'initRate' to a 'finalRate' in constant increments over the course of a
@@ -62,12 +59,11 @@ public class ConstantStepWiseRateIncreaser {
 
         int numSteps = rampPeriodMillisecs / incrementIntervalMillisecs;
         double spread = (finalRate - initRate) * 1.0;
-        double rateIncrementPerStep = spread / numSteps;
 
         this.initRate = initRate;
         this.finalRate = finalRate;
         this.incrementIntervalMillisecs = incrementIntervalMillisecs;
-        this.rateIncrementPerStep = rateIncrementPerStep;
+        this.rateIncrementPerStep = spread / numSteps;
     }
 
     public double getRateForGivenClockTime(long baseReferenceTime, long clockTime) {

--- a/ndbench-core/src/test/java/com/netflix/ndbench/core/NdbenchDriverTest.java
+++ b/ndbench-core/src/test/java/com/netflix/ndbench/core/NdbenchDriverTest.java
@@ -1,14 +1,10 @@
 package com.netflix.ndbench.core;
 
 import com.google.common.util.concurrent.RateLimiter;
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
 import com.netflix.archaius.api.inject.RuntimeLayer;
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.archaius.test.Archaius2TestConfig;
-import com.netflix.archaius.test.TestPropertyOverride;
 import com.netflix.governator.guice.test.ModulesForTesting;
-import com.netflix.governator.guice.test.ReplaceWithMock;
 import com.netflix.governator.guice.test.junit4.GovernatorJunit4ClassRunner;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
@@ -17,23 +13,15 @@ import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
 import com.netflix.ndbench.core.config.IConfiguration;
 import com.netflix.ndbench.core.defaultimpl.NdBenchGuiceModule;
 import com.netflix.ndbench.core.operations.WriteOperation;
-import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 
 import javax.inject.Inject;
-import javax.inject.Singleton;
-
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.*;
 
 @RunWith(GovernatorJunit4ClassRunner.class)

--- a/ndbench-core/src/test/java/com/netflix/ndbench/core/RPSCountTest.java
+++ b/ndbench-core/src/test/java/com/netflix/ndbench/core/RPSCountTest.java
@@ -5,8 +5,6 @@ import com.netflix.ndbench.api.plugin.NdBenchMonitor;
 import com.netflix.ndbench.core.config.IConfiguration;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.libex.test.TestBase;

--- a/ndbench-core/src/test/java/com/netflix/ndbench/core/util/ConstantStepWiseRateIncreaserTest.java
+++ b/ndbench-core/src/test/java/com/netflix/ndbench/core/util/ConstantStepWiseRateIncreaserTest.java
@@ -1,12 +1,6 @@
 package com.netflix.ndbench.core.util;
 
-import com.google.common.collect.ImmutableList;
-import com.netflix.ndbench.api.plugin.NdBenchMonitor;
-import com.netflix.ndbench.core.util.ConstantStepWiseRateIncreaser;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;

--- a/ndbench-core/src/test/java/org/libex/logging/log4j/InMemoryAppender.java
+++ b/ndbench-core/src/test/java/org/libex/logging/log4j/InMemoryAppender.java
@@ -1,15 +1,13 @@
 package org.libex.logging.log4j;
 
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.ThreadSafe;
-
+import com.google.common.collect.ImmutableList;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.spi.LoggingEvent;
 
-import com.google.common.collect.ImmutableList;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Appender that maintains the logging events in memory.

--- a/ndbench-core/src/test/java/org/libex/test/google/NullPointerTester.java
+++ b/ndbench-core/src/test/java/org/libex/test/google/NullPointerTester.java
@@ -1,37 +1,25 @@
 package org.libex.test.google;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Member;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.ConcurrentMap;
-
-import javax.annotation.Nullable;
-
-import junit.framework.Assert;
-import junit.framework.AssertionFailedError;
-
 import com.google.common.base.Converter;
 import com.google.common.base.Objects;
-import com.google.common.collect.ClassToInstanceMap;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.MutableClassToInstanceMap;
+import com.google.common.collect.*;
 import com.google.common.reflect.Invokable;
 import com.google.common.reflect.Parameter;
 import com.google.common.reflect.Reflection;
 import com.google.common.reflect.TypeToken;
 import com.google.common.testing.ArbitraryInstances;
 import com.google.common.testing.NullPointerTester.Visibility;
+import junit.framework.Assert;
+import junit.framework.AssertionFailedError;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * This is a modified version of {@link com.google.common.testing.NullPointerTester} to enable configuration

--- a/ndbench-core/src/test/java/org/libex/test/logging/log4j/Log4jCapturer.java
+++ b/ndbench-core/src/test/java/org/libex/test/logging/log4j/Log4jCapturer.java
@@ -1,30 +1,11 @@
 package org.libex.test.logging.log4j;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Predicates.and;
-import static com.google.common.collect.Iterables.find;
-import static com.google.common.collect.Iterables.transform;
-import static com.google.common.collect.Lists.newArrayList;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.libex.logging.log4j.LoggingEventsEx.toMessage;
-
-import java.util.List;
-
-import javax.annotation.ParametersAreNonnullByDefault;
-import javax.annotation.concurrent.NotThreadSafe;
-
-import org.apache.log4j.Appender;
-import org.apache.log4j.Layout;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.apache.log4j.*;
 import org.apache.log4j.spi.LoggingEvent;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matcher;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.hamcrest.StringDescription;
+import org.hamcrest.*;
 import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -33,9 +14,18 @@ import org.libex.hamcrest.IsThrowable;
 import org.libex.logging.log4j.InMemoryAppender;
 import org.libex.logging.log4j.LoggingEventsEx;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Predicates.and;
+import static com.google.common.collect.Iterables.find;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.libex.logging.log4j.LoggingEventsEx.toMessage;
 
 /**
  *

--- a/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsRestPlugin.java
+++ b/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsRestPlugin.java
@@ -105,7 +105,6 @@ public class EsRestPlugin implements NdBenchAbstractClient<WriteResult> {
             throw new IllegalArgumentException( "bulkWriteBatchSize can't be negative'");
         }
 
-
         List<HttpHost> endpoints = getEndpoints(discoverer, esConfig);
         restClient = RestClient.builder(endpoints.toArray(new HttpHost[0])).build();
 
@@ -202,20 +201,12 @@ public class EsRestPlugin implements NdBenchAbstractClient<WriteResult> {
     // Will never be called by driver if isAutoTuneEnabled=false -- for that reason autoTuner is allowed to be null.
     // See constructor for details.
     //
-    public double autoTuneWriteRateLimit(double currentRateLimit, WriteResult event, NdBenchMonitor runStats) {
+    // Note: this method will only be called after the ndbench driver tries to perform a writeSingle operation
+    //
+    @Override
+    public Double autoTuneWriteRateLimit(Double currentRateLimit, WriteResult event, NdBenchMonitor runStats) {
+        assert autoTuner != null;
         return autoTuner.recommendNewRate(currentRateLimit, event, runStats);
-    }
-
-    String getIndexUrl() {          // this method is only for testing
-        return ES_INDEX_TYPE_RESOURCE_PATH;
-    }
-
-    EsWriter getWriter() {          // this method is only for testing
-        return writer;
-    }
-
-    void deleteIndex(String indexName) throws IOException {
-        restClient.performRequest("DELETE", "/" + indexName);
     }
 
     private String getUrlToDocGivenId(String key) {

--- a/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsRestPlugin.java
+++ b/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsRestPlugin.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsUtils.java
+++ b/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsUtils.java
@@ -2,7 +2,10 @@ package com.netflix.ndbench.plugin.es;
 
 import com.google.gson.Gson;
 import com.netflix.ndbench.api.plugin.DataGenerator;
-import okhttp3.*;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsWriter.java
+++ b/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsWriter.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 
@@ -58,7 +59,6 @@ class EsWriter {
     private final String esDocType;
     private final boolean isBulkWrite;
 
-    private static final ImmutableMap<String, String> EMPTY_PARAMS = ImmutableMap.of();
     private static final BasicHeader CONTENT_TYPE_HDR_JSON = new BasicHeader("Content-Type", "application/json");
 
     private final DataGenerator dataGenerator;
@@ -129,7 +129,7 @@ class EsWriter {
                 restClient.performRequest(
                         "PUT",
                         url,
-                        EMPTY_PARAMS,
+                        Collections.emptyMap(),
                         new StringEntity(doc),
                         CONTENT_TYPE_HDR_JSON);
         logger.debug(
@@ -154,7 +154,7 @@ class EsWriter {
         }
         String json = stringBuilder.toString();
         logger.trace("bulk write payload was: {}", json);
-        restClient.performRequest("POST", "/_bulk", EMPTY_PARAMS, new StringEntity(json), CONTENT_TYPE_HDR_JSON);
+        restClient.performRequest("POST", "/_bulk", Collections.emptyMap(), new StringEntity(json), CONTENT_TYPE_HDR_JSON);
     }
 
 

--- a/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsWriter.java
+++ b/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsWriter.java
@@ -1,6 +1,5 @@
 package com.netflix.ndbench.plugin.es;
 
-import com.google.common.collect.ImmutableMap;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;

--- a/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AbstractPluginTest.java
+++ b/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AbstractPluginTest.java
@@ -41,28 +41,6 @@ public class AbstractPluginTest {
         }
     }
 
-    protected static DataGenerator alwaysSameValueGenerator = new DataGenerator() {
-        @Override
-        public String getRandomString() {
-            return "hello";
-        }
-
-        @Override
-        public String getRandomValue() {
-            return "hello";
-        }
-
-        @Override
-        public Integer getRandomInteger() {
-            return 1;
-        }
-
-        @Override
-        public Integer getRandomIntegerValue() {
-            return 1;
-        }
-    };
-
     protected static IEsConfig getConfig(final int portNum,
                                          @Nullable final String forcedHostName,
                                          final String indexName,

--- a/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AbstractPluginTest.java
+++ b/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AbstractPluginTest.java
@@ -1,7 +1,6 @@
 package com.netflix.ndbench.plugin.es;
 
 import com.google.common.collect.ImmutableList;
-import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.core.config.IConfiguration;
 import com.netflix.ndbench.core.discovery.IClusterDiscovery;
 import org.slf4j.Logger;

--- a/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AutotuneTest.java
+++ b/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AutotuneTest.java
@@ -7,9 +7,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
 
 public class AutotuneTest extends AbstractPluginTest {
     @Test

--- a/ndbench-geode-plugins/src/main/java/com/netflix/ndbench/geode/plugin/GeodeCloudPlugin.java
+++ b/ndbench-geode-plugins/src/main/java/com/netflix/ndbench/geode/plugin/GeodeCloudPlugin.java
@@ -1,9 +1,5 @@
 package com.netflix.ndbench.geode.plugin;
 
-import java.net.URI;
-import java.util.List;
-import java.util.Properties;
-
 import com.google.inject.Singleton;
 import com.netflix.archaius.api.PropertyFactory;
 import com.netflix.ndbench.api.plugin.DataGenerator;
@@ -18,6 +14,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.net.URI;
+import java.util.List;
+import java.util.Properties;
 
 /**
  *


### PR DESCRIPTION
    - eliminate rate increase table in favor of computing auto tuned rate on the fly using the Gennadiy Formula.
    - add additional tests to verify the ability to recover rate ramp-up behavior once error rate falls below threshold after initially exceeding it.
