### PR TITLE
renaming useTinkerpop to useJanusgraphTransaction

### DIFF
--- a/ndbench-janusgraph-plugins/src/main/java/com/netflix/ndbench/plugins/janusgraph/configs/IJanusGraphConfig.java
+++ b/ndbench-janusgraph-plugins/src/main/java/com/netflix/ndbench/plugins/janusgraph/configs/IJanusGraphConfig.java
@@ -11,8 +11,8 @@ import com.netflix.archaius.api.annotations.DefaultValue;
 @Configuration(prefix = "ndbench.config.janusgraph")
 public interface IJanusGraphConfig {
     // One can benchmark either the Tinkerpop API or the JanusGraph Core API if needed
-    @DefaultValue("true")
-    boolean isUsingTinkerpop();
+    @DefaultValue("false")
+    boolean useJanusgraphTransaction();
 
     @DefaultValue("127.0.0.1")
     String getStorageHostname();


### PR DESCRIPTION
Janusgraph uses Tinkerpop underneath therefore using more representative names as folks may be confused that other than `useTinkerpop` does not use Tinkerpop.