### PR TITLE
Dependency excludes ensure slf4j bound to log4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ The gradlew script will pull down all necessary gradle components/infrastructure
 
 NdBench provides several default implementations ( NdBenchConfiguration, LocalClusterDiscovery etc). You can use these or choose to create your own. NdBench currently works on AWS or your local environment. We are open to contributions to support other platforms as well.
 
+
+## Build Dependencies
+
+Contributors to the Ndbench code base interested in viewing the tree of dependencies used by Gradle to build the project can invoke the command
+
+    ./gradlew allDeps
+
+This will print the dependency for each subproject.
+
+
+
 ## How to
 
 The first step before building ndbench is to configure the interfaces related to your environment in the [InjectedWebListener](https://github.com/Netflix/ndbench/blob/master/ndbench-web/src/main/java/com/netflix/ndbench/defaultimpl/InjectedWebListener.java). Checkout the [Wiki](https://github.com/Netflix/ndbench/wiki/Configuration) for further explanation on what interfaces to bind based on your environment. 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,6 @@ The gradlew script will pull down all necessary gradle components/infrastructure
 NdBench provides several default implementations ( NdBenchConfiguration, LocalClusterDiscovery etc). You can use these or choose to create your own. NdBench currently works on AWS or your local environment. We are open to contributions to support other platforms as well.
 
 
-## Build Dependencies
-
-Contributors to the Ndbench code base interested in viewing the tree of dependencies used by Gradle to build the project can invoke the command
-
-    ./gradlew allDeps
-
-This will print the dependency for each subproject.
-
 
 
 ## How to

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,14 @@ apply from: file('gradle/license.gradle')
 apply from: file('gradle/release.gradle')
 */
 
+allprojects {
+    
+    // https://www.developerfeed.com/how-do-disable-low-level-logging-apache-common-packages/
+
+    // handy command display all transitive dependencies of each subproject
+    task allDeps(type: DependencyReportTask) {}
+}
+
 
 subprojects {
     apply plugin: 'nebula.netflixoss'

--- a/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/common/NdBenchConstants.java
+++ b/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/common/NdBenchConstants.java
@@ -22,8 +22,7 @@ package com.netflix.ndbench.api.plugin.common;
  */
 public final class NdBenchConstants {
     public static final String WEBAPP_NAME = "ndbench";
-    public static final String PROP_NAMESPACE_NO_DOT = WEBAPP_NAME + ".config";
-    public static final String PROP_NAMESPACE =  PROP_NAMESPACE_NO_DOT + ".";
+    public static final String PROP_NAMESPACE =  (WEBAPP_NAME + ".config") + ".";
 
     public static final String NUM_KEYS="numKeys";
     public static final String NUM_VALUES="numValues";

--- a/ndbench-core/build.gradle
+++ b/ndbench-core/build.gradle
@@ -27,10 +27,6 @@ dependencies {
     testCompile 'com.google.guava:guava-testlib:17'
     testCompile 'com.google.guava:guava-testlib:17.0'
     testCompile 'org.mockito:mockito-all:1.+'
-    
-
-
-
-    
-
+    testCompile 'org.mockito:mockito-all:1.+'
+    testCompile 'commons-io:commons-io:2.4'
 }

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
@@ -24,7 +24,7 @@ import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
 /**
  * @author vchella
  */
-@Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE_NO_DOT)
+@Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE)
 public interface IConfiguration {
 
     void initialize();

--- a/ndbench-core/src/test/java/com/ConfigurationPropertiesTest.java
+++ b/ndbench-core/src/test/java/com/ConfigurationPropertiesTest.java
@@ -1,0 +1,34 @@
+package com;
+
+import com.netflix.archaius.guice.ArchaiusModule;
+import com.netflix.governator.guice.test.ModulesForTesting;
+import com.netflix.governator.guice.test.junit4.GovernatorJunit4ClassRunner;
+import com.netflix.ndbench.core.config.IConfiguration;
+import com.netflix.ndbench.core.defaultimpl.NdBenchGuiceModule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+
+/**
+ * Verifies that system properties may be used to set values returned by dynamic  proxies generated from
+ * {@link com.netflix.ndbench.core.config.IConfiguration},using the namespace prefix "ndbench.config."
+ *
+ */
+@RunWith(GovernatorJunit4ClassRunner.class)
+@ModulesForTesting({NdBenchGuiceModule.class, ArchaiusModule.class})
+public class ConfigurationPropertiesTest {
+    static {
+        System.setProperty("ndbench.config.numKeys", "777");
+    }
+
+    @Inject
+    IConfiguration config;
+
+    @Test
+    public void testInvokingProcessMethodOnWriteOperationSetsNewRateLimit() throws Exception {
+        assert (config.getNumKeys() == 777);
+    }
+}
+

--- a/ndbench-janusgraph-plugins/build.gradle
+++ b/ndbench-janusgraph-plugins/build.gradle
@@ -3,10 +3,18 @@ dependencies {
     compile project(':ndbench-core')
 
     // JanusGraph
-    compile 'org.janusgraph:janusgraph-core:0.2.0'
-    compile 'org.janusgraph:janusgraph-cassandra:0.2.0'
-    compile 'org.janusgraph:janusgraph-cql:0.2.0'
-    compile 'org.janusgraph:janusgraph-es:0.2.0'
+    compile ('org.janusgraph:janusgraph-core:0.2.0') {
+        exclude group: 'ch.qos.logback'
+    }
+    compile ('org.janusgraph:janusgraph-cassandra:0.2.0') {
+        exclude group: 'ch.qos.logback'
+    }
+    compile ('org.janusgraph:janusgraph-cql:0.2.0') {
+        exclude group: 'ch.qos.logback'
+    }
+    compile ('org.janusgraph:janusgraph-es:0.2.0') {
+        exclude group: 'ch.qos.logback'
+    }
 
     // Elastic Search
     compile 'org.elasticsearch:elasticsearch:5.6.3'

--- a/ndbench-web/build.gradle
+++ b/ndbench-web/build.gradle
@@ -4,7 +4,9 @@ apply plugin: "org.akhikhl.gretty"
 dependencies {
     compile project(':ndbench-core')
     compile project(':ndbench-api')
-    compile project(':ndbench-cass-plugins')
+    compile (project(':ndbench-cass-plugins')) {
+        exclude group: 'ch.qos.logback'
+    }
     compile project(':ndbench-dyno-plugins')
     compile project(':ndbench-sample-plugins')
     compile project(':ndbench-es-plugins')

--- a/ndbench-web/src/test/java/com/test/Log4jConfigurationTest.java
+++ b/ndbench-web/src/test/java/com/test/Log4jConfigurationTest.java
@@ -1,0 +1,36 @@
+package com.test;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class Log4jConfigurationTest {
+    static {
+        try {
+            File temp = File.createTempFile("temp-file-name", ".log");
+            temp.deleteOnExit();
+            FileUtils.writeStringToFile(temp, "log4j.logger.com.test=TRACE");
+            System.setProperty(
+                    "log4j.configuration",
+                    "file:///" + temp.getAbsolutePath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void verifyLog4jPropertiesConfigurationWorksAsExpected() throws Exception {
+        final Logger logger = LoggerFactory.getLogger(Log4jConfigurationTest .class);
+        if (! logger.isTraceEnabled()) {
+            throw new RuntimeException("slf4j seems not to be bound to a log4j implementation. check depdendencies!");
+        } else {
+            System.out.println("IS DEBUG ENABLED:" + logger);
+        }
+    }
+}
+

--- a/ndbench-web/src/test/java/com/test/Log4jConfigurationTest.java
+++ b/ndbench-web/src/test/java/com/test/Log4jConfigurationTest.java
@@ -28,8 +28,6 @@ public class Log4jConfigurationTest {
         final Logger logger = LoggerFactory.getLogger(Log4jConfigurationTest .class);
         if (! logger.isTraceEnabled()) {
             throw new RuntimeException("slf4j seems not to be bound to a log4j implementation. check depdendencies!");
-        } else {
-            System.out.println("IS DEBUG ENABLED:" + logger);
         }
     }
 }


### PR DESCRIPTION
* exclude dependencies which bring in a logback implementation so that log4 binding wins
* add allDeps build target to view dependency tree for each sub-project
    - updated README to document usage of this feature.
* change string constant for "ndbench.config" property prefix to include "." to decouple from Archaius2 implementation.



DETAILS


change string constant for "ndbench.config" property prefix to include "." to decouple from Archaius2 implementation.

    The above mentioned constant resolves to a string that happens to work out because
    com.netflix.archaius.ConfigProxyFactory#derivePrefix will append a '.' to a prefix if it is missing.
    This change explicitly adds the "." to the constant which is clearer code-wise, and is decoupled from current
    implementation of derivePrefix function in Archaius2.

    Added com.ConfigurationPropertiesTest to verify that proxy generated from IConfiguration 
    worked correctly before and after the change.


* exclude dependencies which bring in a logback implementation so that log4 binding wins


    Without this change it is not possible to configure log4j dependencies via a log4j.properties file 
    because the binding from the slf4j API to an implementation that woudl cause a log4j implementation to 'win'
    is undercut by the presence of logback on the classpath.  This can be seen when running ndbench in Intellij
    (using the tomcat server run configuration) in the main output window.   Before this PR, we got this error 
    regarding multiple SLF4J bindings.

        SLF4J: Class path contains multiple SLF4J bindings.
        SLF4J: Found binding in [jar:file:/home/cbedford/OSS.ndb/ndbench/ndbench-web/build/libs/exploded/ndbench-web-0.3.7-SNAPSHOT.war/WEB-INF/lib/logback-classic-1.1.2.jar!/org/slf4j/impl/StaticLoggerBinder.class]
        SLF4J: Found binding in [jar:file:/home/cbedford/OSS.ndb/ndbench/ndbench-web/build/libs/exploded/ndbench-web-0.3.7-SNAPSHOT.war/WEB-INF/lib/slf4j-log4j12-1.7.21.jar!/org/slf4j/impl/StaticLoggerBinder.class]
        SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
        SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]

    In this case slf4j was bound to the logback implementation, but I found no guarantee in the documentation that this is deterministic. 
    Rather than leave the question of "which binding wins" up to chance, I have explicitly excluded transitive dependencies which used to bring in
    logback.

    The unit test com.test.Log4jConfigurationTest validates this change. Before introducing the build.gradle dependency excludes
    the test failed. With the excludes the test passes. 

