### PR TITLE
Support configuration of timeouts for es plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ The gradlew script will pull down all necessary gradle components/infrastructure
 
 NdBench provides several default implementations ( NdBenchConfiguration, LocalClusterDiscovery etc). You can use these or choose to create your own. NdBench currently works on AWS or your local environment. We are open to contributions to support other platforms as well.
 
+
+## Build Dependencies
+
+Contributors to the Ndbench code base interested in viewing the tree of dependencies used by Gradle to build the project can invoke the command
+
+    ./gradlew allDeps
+
+This will print the dependency for each subproject.
+
+
+
 ## How to
 
 The first step before building ndbench is to configure the interfaces related to your environment in the [InjectedWebListener](https://github.com/Netflix/ndbench/blob/master/ndbench-web/src/main/java/com/netflix/ndbench/defaultimpl/InjectedWebListener.java). Checkout the [Wiki](https://github.com/Netflix/ndbench/wiki/Configuration) for further explanation on what interfaces to bind based on your environment. 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,6 @@ The gradlew script will pull down all necessary gradle components/infrastructure
 NdBench provides several default implementations ( NdBenchConfiguration, LocalClusterDiscovery etc). You can use these or choose to create your own. NdBench currently works on AWS or your local environment. We are open to contributions to support other platforms as well.
 
 
-## Build Dependencies
-
-Contributors to the Ndbench code base interested in viewing the tree of dependencies used by Gradle to build the project can invoke the command
-
-    ./gradlew allDeps
-
-This will print the dependency for each subproject.
-
 
 
 ## How to

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,14 @@ apply from: file('gradle/license.gradle')
 apply from: file('gradle/release.gradle')
 */
 
+allprojects {
+    
+    // https://www.developerfeed.com/how-do-disable-low-level-logging-apache-common-packages/
+
+    // handy command display all transitive dependencies of each subproject
+    task allDeps(type: DependencyReportTask) {}
+}
+
 
 subprojects {
     apply plugin: 'nebula.netflixoss'

--- a/ndbench-core/build.gradle
+++ b/ndbench-core/build.gradle
@@ -27,10 +27,6 @@ dependencies {
     testCompile 'com.google.guava:guava-testlib:17'
     testCompile 'com.google.guava:guava-testlib:17.0'
     testCompile 'org.mockito:mockito-all:1.+'
-    
-
-
-
-    
-
+    testCompile 'org.mockito:mockito-all:1.+'
+    testCompile 'commons-io:commons-io:2.4'
 }

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
@@ -24,7 +24,7 @@ import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
 /**
  * @author vchella
  */
-@Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE_NO_DOT)
+@Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE)
 public interface IConfiguration {
 
     void initialize();

--- a/ndbench-core/src/test/java/com/ConfigurationPropertiesTest.java
+++ b/ndbench-core/src/test/java/com/ConfigurationPropertiesTest.java
@@ -1,0 +1,34 @@
+package com;
+
+import com.netflix.archaius.guice.ArchaiusModule;
+import com.netflix.governator.guice.test.ModulesForTesting;
+import com.netflix.governator.guice.test.junit4.GovernatorJunit4ClassRunner;
+import com.netflix.ndbench.core.config.IConfiguration;
+import com.netflix.ndbench.core.defaultimpl.NdBenchGuiceModule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+
+/**
+ * Verifies that system properties may be used to set values returned by dynamic  proxies generated from
+ * {@link com.netflix.ndbench.core.config.IConfiguration},using the namespace prefix "ndbench.config."
+ *
+ */
+@RunWith(GovernatorJunit4ClassRunner.class)
+@ModulesForTesting({NdBenchGuiceModule.class, ArchaiusModule.class})
+public class ConfigurationPropertiesTest {
+    static {
+        System.setProperty("ndbench.config.numKeys", "777");
+    }
+
+    @Inject
+    IConfiguration config;
+
+    @Test
+    public void testInvokingProcessMethodOnWriteOperationSetsNewRateLimit() throws Exception {
+        assert (config.getNumKeys() == 777);
+    }
+}
+

--- a/ndbench-core/src/test/java/com/netflix/ndbench/ConfigurationPropertiesTest.java
+++ b/ndbench-core/src/test/java/com/netflix/ndbench/ConfigurationPropertiesTest.java
@@ -1,0 +1,34 @@
+package com.netflix.ndbench;
+
+import com.netflix.archaius.guice.ArchaiusModule;
+import com.netflix.governator.guice.test.ModulesForTesting;
+import com.netflix.governator.guice.test.junit4.GovernatorJunit4ClassRunner;
+import com.netflix.ndbench.core.config.IConfiguration;
+import com.netflix.ndbench.core.defaultimpl.NdBenchGuiceModule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+
+/**
+ * Verifies that system properties may be used to set values returned by dynamic  proxies generated from
+ * {@link com.netflix.ndbench.core.config.IConfiguration},using the namespace prefix "ndbench.config."
+ *
+ */
+@RunWith(GovernatorJunit4ClassRunner.class)
+@ModulesForTesting({NdBenchGuiceModule.class, ArchaiusModule.class})
+public class ConfigurationPropertiesTest {
+    static {
+        System.setProperty("ndbench.config.numKeys", "777");
+    }
+
+    @Inject
+    IConfiguration config;
+
+    @Test
+    public void testInvokingProcessMethodOnWriteOperationSetsNewRateLimit() throws Exception {
+        assert (config.getNumKeys() == 777);
+    }
+}
+

--- a/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsWriter.java
+++ b/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/EsWriter.java
@@ -152,8 +152,12 @@ class EsWriter {
             stringBuilder.append("\n");
         }
         String json = stringBuilder.toString();
-        logger.trace("bulk write payload was: {}", json);
-        restClient.performRequest("POST", "/_bulk", Collections.emptyMap(), new StringEntity(json), CONTENT_TYPE_HDR_JSON);
+        Response response = restClient.performRequest("POST", "/_bulk", Collections.emptyMap(), new StringEntity(json), CONTENT_TYPE_HDR_JSON);
+        if (logger.isTraceEnabled()) {
+            logger.trace("got response: {} after sending bulk write payload of: {}", response, json);
+        } else {
+            logger.debug("GOT response: {} after sending bulk write payload", response);
+        }
     }
 
 
@@ -164,7 +168,7 @@ class EsWriter {
                 esDocType,
                 key);
         String retval = metadata + "\n" + doc;           // yes. could do in format, but this is clearer
-        logger.debug("bulk write payload for one doc: {}", retval);
+        logger.trace("bulk write payload for one doc: {}", retval);
         return retval;
     }
 

--- a/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/IEsConfig.java
+++ b/ndbench-es-plugins/src/main/java/com/netflix/ndbench/plugin/es/IEsConfig.java
@@ -44,26 +44,100 @@ public interface IEsConfig {
      * used in a <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/_batch_processing.html">
      * bulk indexing request</a>. If zero is specified, then no rolling will occur, and no date pattern will be used in
      * the name of the index, otherwise the number specified determines how many times the index will 'roll' per day.
-     *
+     * <p>
      * If you wish to roll your indices every hour just take the number of times you wish to roll per hour and
      * multiply by 24 (number of hours in a day) to get the total number of rolls per day.
-     *
+     * <p>
      * Given a return value for this method of 'N' greater than 0, then N times per day  the currently-being-written-to
      * index will be closed, and subsequent writes will be directed to a new index with a different name formed by:
      * the prefix determined by {@link #getIndexName()},  today's date (GMT-based) followed by "-N" where
      * 'N' is the number of the roll in a given day.
-     *
+     * <p>
      * Allowable return values for this function must evenly divide 1440, be at least zero, and be no greater than 1440.
      * The maximum value (1440), would indicate indices are rolled every once every day.
      * <p>
-     *
      * Example 1:  to roll twice a day specify '2' as the return value. To roll twice per hour specify 2 * 24 == 48
      * as the return value.
-     *
-     *
+     * <p>
      * Example 2:  if you wanted to roll 7 times per hour you would be out of luck as 1440/(7*24) is not an integer.
      *
      */
     @DefaultValue("0")
     Integer getIndexRollsPerDay();
+
+
+    /**
+     * Sets the corresponding parameter in the underlying
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/index.html">http client</a> connection that is
+     * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_timeouts.html">configured
+     * and used</a> by the ElasticSearch Rest client, which itself is used by the ES_REST Ndbench client plugin.
+     * <p>
+     * Adjustments to this setting will trigger calls to
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html#setConnectionRequestTimeout(int)">
+     * the Elasticsearch Rest client's setConnectionRequestTimeout method</a>.
+     * <p>
+     * Note that the underlying connection's documentation describes values given in milliseconds, whereas this API
+     * requires you to specify the value in seconds.
+     * <p>
+     * Also note: it is advisable to set all timeout parameters that  affect the underlying
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/index.html">http client</a> connection to the same value.
+     */
+    @DefaultValue("120")
+    Integer getConnectTimeoutSeconds();
+
+    /**
+     * Sets the corresponding parameter in the underlying
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/index.html">http client</a> connection that is
+     * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_timeouts.html">configured
+     * and used</a> by the ElasticSearch Rest client, which itself is used by the ES_REST Ndbench client plugin.
+     * <p>
+     * Adjustments to this setting will trigger calls to
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html#setConnectionRequestTimeout(int)">
+     * the Elasticsearch Rest client's setConnectionRequestTimeout method</a>.
+     * <p>
+     * Note that the underlying connection's documentation describes values given in milliseconds, whereas this API
+     * requires you to specify the value in seconds.
+     * <p>
+     * Also note: it is advisable to set all timeout parameters that  affect the underlying
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/index.html">http client</a> connection to the same value.
+     */
+    @DefaultValue("120")
+    Integer getConnectionRequestTimeoutSeconds();
+
+    /**
+     * Sets the corresponding parameter in the underlying
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/index.html">http client</a> connection that is
+     * <a href="https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_timeouts.html">configured
+     * and used</a> by the ElasticSearch Rest client, which itself is used by the ES_REST Ndbench client plugin.
+     * <p>
+     * Adjustments to this setting will trigger calls to
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html#setSocketTimeout(int)">
+     * the Elasticsearch Rest client's setSocketTimeout method</a>.
+     * <p>
+     * Note that the underlying connection's documentation describes values given in milliseconds, whereas this API
+     * requires you to specify the value in seconds.
+     * <p>
+     * Also note: it is advisable to set all timeout parameters that  affect the underlying
+     * <a href="https://hc.apache.org/httpcomponents-client-ga/index.html">http client</a> connection to the same value.
+     */
+    @DefaultValue("120")
+    Integer getSocketTimeoutSeconds();
+
+    /**
+     * Sets the total timeout across all retries for the
+     * <a href="https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/5.6.4/org/elasticsearch/client/RestClient.html">
+     * ElasticSearch Rest client</a> instance  used by the ES_REST Ndbench client plugin.
+     * <p>
+     * <p>
+     * Note that the API for the
+     * <a href="https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/5.6.4/org/elasticsearch/client/RestClientBuilder.html">
+     *     Elasticsearch Rest client builder </a> requires values given in milliseconds, whereas this API requires you
+     * to specify the value in seconds.
+     * <p>
+     * Also note:  generally, it is advisable to set all timeout parameters that  affect the underlying connection to the
+     * same value, but  setting this value to some multiple of  the socket time out value is how you configure
+     * allowed retry attempts.
+     */
+    @DefaultValue("120")
+    Integer getMaxRetryTimeoutSeconds();
 }

--- a/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AbstractPluginTest.java
+++ b/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AbstractPluginTest.java
@@ -87,6 +87,26 @@ public class AbstractPluginTest {
                 return indexRollsPerHour;
             }
 
+            @Override
+            public Integer getConnectTimeoutSeconds() {
+                return 120;
+            }
+
+            @Override
+            public Integer getConnectionRequestTimeoutSeconds() {
+                return 120;
+            }
+
+            @Override
+            public Integer getSocketTimeoutSeconds() {
+                return 120;
+            }
+
+            @Override
+            public Integer getMaxRetryTimeoutSeconds() {
+                return 120;
+            }
+
         };
     }
 

--- a/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/ConfigurationPropertiesTest.java
+++ b/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/ConfigurationPropertiesTest.java
@@ -1,4 +1,4 @@
-package com;
+package com.netflix.ndbench.plugin.es;
 
 import com.netflix.archaius.guice.ArchaiusModule;
 import com.netflix.governator.guice.test.ModulesForTesting;
@@ -13,22 +13,25 @@ import javax.inject.Inject;
 
 /**
  * Verifies that system properties may be used to set values returned by dynamic  proxies generated from
- * {@link com.netflix.ndbench.core.config.IConfiguration},using the namespace prefix "ndbench.config."
+ * {@link IEsConfig},using the namespace prefix "ndbench.config.es".
  *
  */
 @RunWith(GovernatorJunit4ClassRunner.class)
-@ModulesForTesting({NdBenchGuiceModule.class, ArchaiusModule.class})
+@ModulesForTesting({NfndbenchEsModule.class, ArchaiusModule.class})
 public class ConfigurationPropertiesTest {
     static {
-        System.setProperty("ndbench.config.numKeys", "777");
+        System.setProperty("ndbench.config.es.connectTimeoutSeconds", "777");
     }
 
     @Inject
-    IConfiguration config;
+    IEsConfig esConfig;
 
     @Test
     public void testInvokingProcessMethodOnWriteOperationSetsNewRateLimit() throws Exception {
-        assert (config.getNumKeys() == 777);
+        assert (esConfig.getConnectTimeoutSeconds() == 777);
+        assert (esConfig.getConnectionRequestTimeoutSeconds() == 120);
+        assert (esConfig.getSocketTimeoutSeconds() == 120);
+        assert (esConfig.getMaxRetryTimeoutSeconds() == 120);
     }
 }
 

--- a/ndbench-janusgraph-plugins/build.gradle
+++ b/ndbench-janusgraph-plugins/build.gradle
@@ -3,10 +3,18 @@ dependencies {
     compile project(':ndbench-core')
 
     // JanusGraph
-    compile 'org.janusgraph:janusgraph-core:0.2.0'
-    compile 'org.janusgraph:janusgraph-cassandra:0.2.0'
-    compile 'org.janusgraph:janusgraph-cql:0.2.0'
-    compile 'org.janusgraph:janusgraph-es:0.2.0'
+    compile ('org.janusgraph:janusgraph-core:0.2.0') {
+        exclude group: 'ch.qos.logback'
+    }
+    compile ('org.janusgraph:janusgraph-cassandra:0.2.0') {
+        exclude group: 'ch.qos.logback'
+    }
+    compile ('org.janusgraph:janusgraph-cql:0.2.0') {
+        exclude group: 'ch.qos.logback'
+    }
+    compile ('org.janusgraph:janusgraph-es:0.2.0') {
+        exclude group: 'ch.qos.logback'
+    }
 
     // Elastic Search
     compile 'org.elasticsearch:elasticsearch:5.6.3'

--- a/ndbench-web/build.gradle
+++ b/ndbench-web/build.gradle
@@ -4,7 +4,9 @@ apply plugin: "org.akhikhl.gretty"
 dependencies {
     compile project(':ndbench-core')
     compile project(':ndbench-api')
-    compile project(':ndbench-cass-plugins')
+    compile (project(':ndbench-cass-plugins')) {
+        exclude group: 'ch.qos.logback'
+    }
     compile project(':ndbench-dyno-plugins')
     compile project(':ndbench-sample-plugins')
     compile project(':ndbench-es-plugins')

--- a/ndbench-web/src/test/java/com/test/Log4jConfigurationTest.java
+++ b/ndbench-web/src/test/java/com/test/Log4jConfigurationTest.java
@@ -1,0 +1,36 @@
+package com.test;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class Log4jConfigurationTest {
+    static {
+        try {
+            File temp = File.createTempFile("temp-file-name", ".log");
+            temp.deleteOnExit();
+            FileUtils.writeStringToFile(temp, "log4j.logger.com.test=TRACE");
+            System.setProperty(
+                    "log4j.configuration",
+                    "file:///" + temp.getAbsolutePath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void verifyLog4jPropertiesConfigurationWorksAsExpected() throws Exception {
+        final Logger logger = LoggerFactory.getLogger(Log4jConfigurationTest .class);
+        if (! logger.isTraceEnabled()) {
+            throw new RuntimeException("slf4j seems not to be bound to a log4j implementation. check depdendencies!");
+        } else {
+            System.out.println("IS DEBUG ENABLED:" + logger);
+        }
+    }
+}
+

--- a/ndbench-web/src/test/java/com/test/Log4jConfigurationTest.java
+++ b/ndbench-web/src/test/java/com/test/Log4jConfigurationTest.java
@@ -28,8 +28,6 @@ public class Log4jConfigurationTest {
         final Logger logger = LoggerFactory.getLogger(Log4jConfigurationTest .class);
         if (! logger.isTraceEnabled()) {
             throw new RuntimeException("slf4j seems not to be bound to a log4j implementation. check depdendencies!");
-        } else {
-            System.out.println("IS DEBUG ENABLED:" + logger);
         }
     }
 }


### PR DESCRIPTION
This PR should be reviewed once this PR has been merged -> https://github.com/Netflix/ndbench/pull/65  (as it builds on that PR).

DETAILS

    Support configuration of timeouts for es plugin.  Default timeout value will reduce number of annoying timeouts occuring in ES benchmarks.
    Also, provides end user with configuration knobs to tweak timeout settings on underlying http client connection.
