### PR TITLE
Make AWS_ASG discovery find instances cross reservations

### DIFF
--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AwsAsgDiscovery.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AwsAsgDiscovery.java
@@ -102,7 +102,7 @@ public class AwsAsgDiscovery implements IClusterDiscovery {
             instanceIps =  insRes.getReservations().get(0)
                     .getInstances()
                     .stream()
-                    .map(Instance::getPrivateIpAddress)
+                    .map(Instance::getPublicDnsName)
                     .collect(Collectors.toList());
 
 

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AwsAsgDiscovery.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AwsAsgDiscovery.java
@@ -7,22 +7,18 @@ import com.amazonaws.services.autoscaling.AmazonAutoScaling;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder;
 import com.amazonaws.services.autoscaling.model.*;
 import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
-import com.amazonaws.services.ec2.model.Reservation;
+import com.amazonaws.services.ec2.model.Instance;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.netflix.ndbench.core.config.IConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.amazonaws.services.ec2.model.Instance;
 
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -59,9 +55,6 @@ public class AwsAsgDiscovery implements IClusterDiscovery {
 
     public List<String> getRacMembership()
     {
-        List<String> instanceIps = new LinkedList<>();
-
-
          /*
          * Create your credentials file at ~/.aws/credentials (C:\Users\USER_NAME\.aws\credentials for Windows users)
          * and save the following lines after replacing the underlined values with your own.
@@ -100,16 +93,17 @@ public class AwsAsgDiscovery implements IClusterDiscovery {
 
             DescribeInstancesResult insRes = ec2Client.describeInstances(insReq);
 
-            instanceIps =  insRes.getReservations().stream()
+            Set<String> instanceDnsNames = insRes.getReservations().stream()
                     .flatMap(r -> r.getInstances().stream())
                     .map(Instance::getPublicDnsName)
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toSet());
 
-            return instanceIps;
+            return new ArrayList<>(instanceDnsNames);
         }
         catch (Exception e)
         {
             logger.error("Exception in getting private IPs from current ASG",e);
+            return Collections.emptyList();
         }
         finally
         {
@@ -118,7 +112,6 @@ public class AwsAsgDiscovery implements IClusterDiscovery {
             if(ec2Client !=null)
                 ec2Client.shutdown();
         }
-        return instanceIps;
     }
 
     private String getCurrentAsgName()

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AwsAsgDiscovery.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/discovery/AwsAsgDiscovery.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.Reservation;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.netflix.ndbench.core.config.IConfiguration;
@@ -99,13 +100,10 @@ public class AwsAsgDiscovery implements IClusterDiscovery {
 
             DescribeInstancesResult insRes = ec2Client.describeInstances(insReq);
 
-            instanceIps =  insRes.getReservations().get(0)
-                    .getInstances()
-                    .stream()
+            instanceIps =  insRes.getReservations().stream()
+                    .flatMap(r -> r.getInstances().stream())
                     .map(Instance::getPublicDnsName)
                     .collect(Collectors.toList());
-
-
 
             return instanceIps;
         }


### PR DESCRIPTION
Currently, in ASG discovery we only load instances from first reservations. I have 4 ndbench nodes in an ASG and 3 of them are loaded in the first batch and the rest one loaded in the last batch, the result is I only get 3 ndbench nodes even I provisioned 4. This PR is addressing this issue.

There are two other improvements for the AWS_ASG discovery:
* Collect public DNS name of ec2 instance instead private IP, so on the UI javascript can make ajax call base on the endpoint
*Sometimes I got duplicate ec2 instances in the cluster member list. Use "Collectors.toSet()" fixed that problem.

