### PR TITLE
Separation of unit and integration test

### DIFF
--- a/ndbench-es-plugins/build.gradle
+++ b/ndbench-es-plugins/build.gradle
@@ -7,6 +7,26 @@ dependencies {
     compile 'org.elasticsearch:elasticsearch:2.3.3'
 }
 
+sourceSets {
+    integrationTest {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+            srcDir file('src/integration-test/java')
+        }
+        resources.srcDir file('src/integration-test/resources')
+    }
+}
+
+configurations {
+    integrationTestCompile.extendsFrom testCompile
+    integrationTestRuntime.extendsFrom testRuntime
+}
+
+task integrationTest(type: Test) {
+    testClassesDir = sourceSets.integrationTest.output.classesDir
+    classpath = sourceSets.integrationTest.runtimeClasspath
+}
 
 
 repositories {

--- a/ndbench-es-plugins/src/integration-test/java/com.netflix.ndbench.plugin.es/EsIntegrationTest.java
+++ b/ndbench-es-plugins/src/integration-test/java/com.netflix.ndbench.plugin.es/EsIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.netflix.ndbench.plugin.es;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.*;
+
+/*
+Verifies behavior of ES REST plugin by bringing up Elastic search in a docker container and operating against that
+instance..
+
+*Note: these tests runs within a Docker container.
+*
+ */
+public class EsIntegrationTest extends AbstractPluginIntegrationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(EsIntegrationTest.class);
+
+    /**
+     * This check is required because DockerComposeRule .waitingForService() checks don't seem to wait for
+     * connections to be establishable on port 9200. There is probably some way
+     * to configure this, but this quick and dirty test does the job for now.
+     * <p>
+     * Note: This is similar to check code in test for transport protocol: could be refactored.
+     */
+    private static FutureTask<Boolean> checkEsServerUpTask = new FutureTask<Boolean>(new Callable<Boolean>() {
+
+
+        @Override
+        public Boolean call() throws Exception {
+            EsRestPlugin plugin = getPlugin("localhost", "test_index_name", false, 0, 9200);
+            while (!checkEsServerUpTask.isCancelled()) {
+                logger.info("Checking if we can connect to elasticsearch (IGNORE EXCEPTIONS, PLEASE)");
+                try {
+                    if (StringUtils.isNotEmpty(EsUtils.httpGet(plugin.getEsRestEndpoint()))) {
+                        logger.info("connection to elasticsearch succeeded !");
+                        return true;           // success -- break out of loop
+                    }
+                } catch (Exception ignored) {
+                }
+                Thread.sleep(100);  // yes. it is an extra 1/10th of a second in happy path. but less code this way.
+            }
+            return false;
+        }
+    });
+
+    @BeforeClass
+    public static void initialize() {
+        if (disableDueToDockerExecutableUnavailability) {
+            throw new IllegalStateException("ES Integration test runs within the Docker container, Docker was not detected in your environment");
+        }
+        if (StringUtils.isNotEmpty(System.getenv("ES_NDBENCH_NO_DOCKER"))) {
+            throw new IllegalStateException("ES Integration test runs within the Docker container, Docker was not detected in your environment");
+        }
+
+        ExecutorService execSvc = Executors.newSingleThreadExecutor();
+        execSvc.submit(checkEsServerUpTask);
+        try {
+            checkEsServerUpTask.get(40, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Exception encountered when checking if ES is up", e);
+        }
+
+        execSvc.shutdownNow();
+
+        checkEsServerUpTask.cancel(true);
+
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        try {
+            if (docker != null) {
+                docker.containers().container(ELASTICSEARCH).stop();
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("I/O exception when trying to stop Docker container.", e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Trying to stop Docker container was unexpectedluy interrupted.", e);
+        }
+    }
+
+    @Test
+    public void testCanReadWhatWeJustWrote() throws Exception {
+        if (disableDueToDockerExecutableUnavailability) {
+            throw new IllegalStateException("ES Integration test runs within the Docker container, Docker was not detected in your environment");
+        }
+
+        testCanReadWhatWeJustWroteUsingPlugin(
+                getPlugin(/* specify host and avoid discovery mechanism */"localhost",
+                        "test_index_name",
+                        false, 0, 9200));
+        testCanReadWhatWeJustWroteUsingPlugin(
+                getPlugin(/* specify host and avoid discovery mechanism */"localhost",
+                        "test_index_name",
+                        true, 0, 9200));
+        testCanReadWhatWeJustWroteUsingPlugin(
+                getPlugin(/* force use of discovery mechanism */null,
+                        "test_index_name",
+                        false, 0, 9200));
+    }
+
+    private void testCanReadWhatWeJustWroteUsingPlugin(EsRestPlugin plugin) throws Exception {
+        String writeResult = plugin.writeSingle("the-key").toString();
+        assert writeResult.contains("numRejectedExecutionExceptions=0");
+
+        assert plugin.readSingle("the-key").equals(EsRestPlugin.RESULT_OK);
+    }
+
+}

--- a/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/EsRestPluginIntegrationTest.java
+++ b/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/EsRestPluginIntegrationTest.java
@@ -12,10 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.*;
 
-/**
- * Verifies behavior of ES REST plugin by bringing up Elastic search in a docker container and operating against that
- * instance..
- */
 @RunWith(GovernatorJunit4ClassRunner.class)
 @ModulesForTesting({})
 public class EsRestPluginIntegrationTest extends AbstractPluginIntegrationTest {
@@ -25,86 +21,6 @@ public class EsRestPluginIntegrationTest extends AbstractPluginIntegrationTest {
 
     private static final Logger logger = LoggerFactory.getLogger(EsRestPluginIntegrationTest.class);
     private static final String ES_HOST_PORT = "http://localhost:9200";
-
-
-    /**
-     * This check is required because DockerComposeRule .waitingForService() checks don't seem to wait for
-     * connections to be establishable on port 9200. There is probably some way
-     * to configure this, but this quick and dirty test does the job for now.
-     * <p>
-     * Note: This is similar to check code in test for transport protocol: could be refactored.
-     */
-    private static FutureTask<Boolean> checkEsServerUpTask = new FutureTask<Boolean>(new Callable<Boolean>() {
-
-
-        @Override
-        public Boolean call() throws Exception {
-            EsRestPlugin plugin = getPlugin("localhost", "test_index_name", false, 0, 9200);
-            while (!checkEsServerUpTask.isCancelled()) {
-                logger.info("Checking if we can connect to elasticsearch (IGNORE EXCEPTIONS, PLEASE)");
-                try {
-                    if (StringUtils.isNotEmpty(EsUtils.httpGet(plugin.getEsRestEndpoint()))) {
-                        logger.info("connection to elasticsearch succeeded !");
-                        return true;           // success -- break out of loop
-                    }
-                } catch (Exception ignored) {
-                }
-                Thread.sleep(100);  // yes. it is an extra 1/10th of a second in happy path. but less code this way.
-            }
-            return false;
-        }
-    });
-
-
-    @BeforeClass
-    public static void initialize() throws Exception {
-        if (disableDueToDockerExecutableUnavailability) {
-            return;
-        }
-        if (StringUtils.isNotEmpty(System.getenv("ES_NDBENCH_NO_DOCKER"))) {
-            return;
-        }
-
-        ExecutorService execSvc = Executors.newSingleThreadExecutor();
-        execSvc.submit(checkEsServerUpTask);
-        checkEsServerUpTask.get(40, TimeUnit.SECONDS);
-        execSvc.shutdownNow();
-
-        checkEsServerUpTask.cancel(true);
-
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        if (disableDueToDockerExecutableUnavailability) {
-            return;
-        }
-        if (StringUtils.isNotEmpty(System.getenv("ES_NDBENCH_NO_DOCKER"))) {
-            return;
-        }
-        docker.containers().container(ELASTICSEARCH).stop();
-    }
-
-
-    @Test
-    public void testCanReadWhatWeJustWrote() throws Exception {
-        if (disableDueToDockerExecutableUnavailability) {
-            return
-                    ;
-        }
-        testCanReadWhatWeJustWroteUsingPlugin(
-                getPlugin(/* specify host and avoid discovery mechanism */"localhost",
-                        "test_index_name",
-                        false, 0, 9200));
-        testCanReadWhatWeJustWroteUsingPlugin(
-                getPlugin(/* specify host and avoid discovery mechanism */"localhost",
-                        "test_index_name",
-                        true, 0, 9200));
-        testCanReadWhatWeJustWroteUsingPlugin(
-                getPlugin(/* force use of discovery mechanism */null,
-                        "test_index_name",
-                        false, 0, 9200));
-    }
 
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Separation of unit and integration test.  The latter is dependent on  existing of a Docker container.

The value add of this PR is:
- Allow explicit invocation of integration test where appropriate.  The current implementation is always a no-op for builds which results in misleading result.
- Eliminate misleading result by throwing exception when dependency (i.e. Docker) is not available when running integration test.
