### PR TITLE
Enabling cluster file config discovery

### DIFF
--- a/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/common/NdBenchConstants.java
+++ b/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/common/NdBenchConstants.java
@@ -53,4 +53,5 @@ public final class NdBenchConstants {
     public static final String DISCOVERY_ENV_CF="CF";
     public static final String DISCOVERY_ENV_AWS="AWS";
     public static final String DISCOVERY_ENV_AWS_ASG="AWS_ASG";
+    public static final String DISCOVERY_ENV_AWS_CONFIG_FILE="CONFIG_FILE";
 }

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CJavaDriverBasePlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CJavaDriverBasePlugin.java
@@ -29,7 +29,7 @@ public abstract class CJavaDriverBasePlugin implements NdBenchClient {
     protected PropertyFactory propertyFactory;
 
     // settings
-    protected static String ClusterName, KeyspaceName, TableName, ClusterContactPoint, Replication;
+    protected static String ClusterName, KeyspaceName, TableName, ClusterContactPoint;
     int connections, port;
 
     protected ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.LOCAL_ONE, ReadConsistencyLevel=ConsistencyLevel.LOCAL_ONE;
@@ -57,7 +57,6 @@ public abstract class CJavaDriverBasePlugin implements NdBenchClient {
         KeyspaceName = propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.keyspace").asString("dev1").get();
         TableName =propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.cfname").asString("emp").get();
         port = propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE + "cass.host.port").asInteger(9042).get();
-        Replication = propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.replication").asString("{'class': 'NetworkTopologyStrategy','eu-west': '3','us-east': '3'}").get();
         connections = propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.connections").asInteger(2).get();
 
         ReadConsistencyLevel = ConsistencyLevel.valueOf(propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.readConsistencyLevel").asString(ConsistencyLevel.LOCAL_ONE.toString()).get());
@@ -107,8 +106,7 @@ public abstract class CJavaDriverBasePlugin implements NdBenchClient {
 
    protected void upsertGenereicKeyspace()
    {
-       System.out.println(Replication);
-       session.execute("CREATE KEYSPACE IF NOT EXISTS " +KeyspaceName+" WITH replication = " +Replication+ ";");
+       session.execute("CREATE KEYSPACE IF NOT EXISTS " +KeyspaceName+" WITH replication = {'class': 'SimpleStrategy','replication_factor': '1'};");
        session.execute("Use " + KeyspaceName);
    }
 }

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CJavaDriverBasePlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CJavaDriverBasePlugin.java
@@ -29,8 +29,8 @@ public abstract class CJavaDriverBasePlugin implements NdBenchClient {
     protected PropertyFactory propertyFactory;
 
     // settings
-    protected static String ClusterName, KeyspaceName, TableName, ClusterContactPoint;
-    int port;
+    protected static String ClusterName, KeyspaceName, TableName, ClusterContactPoint, Replication;
+    int connections, port;
 
     protected ConsistencyLevel WriteConsistencyLevel=ConsistencyLevel.LOCAL_ONE, ReadConsistencyLevel=ConsistencyLevel.LOCAL_ONE;
 
@@ -57,6 +57,8 @@ public abstract class CJavaDriverBasePlugin implements NdBenchClient {
         KeyspaceName = propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.keyspace").asString("dev1").get();
         TableName =propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.cfname").asString("emp").get();
         port = propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE + "cass.host.port").asInteger(9042).get();
+        Replication = propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.replication").asString("{'class': 'NetworkTopologyStrategy','eu-west': '3','us-east': '3'}").get();
+        connections = propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.connections").asInteger(2).get();
 
         ReadConsistencyLevel = ConsistencyLevel.valueOf(propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.readConsistencyLevel").asString(ConsistencyLevel.LOCAL_ONE.toString()).get());
         WriteConsistencyLevel = ConsistencyLevel.valueOf(propertyFactory.getProperty(NdBenchConstants.PROP_NAMESPACE +"cass.writeConsistencyLevel").asString(ConsistencyLevel.LOCAL_ONE.toString()).get());
@@ -90,7 +92,7 @@ public abstract class CJavaDriverBasePlugin implements NdBenchClient {
 
         Logger.info("Cassandra  Cluster: " + ClusterName);
 
-        this.cluster = cassJavaDriverManager.registerCluster(ClusterName,ClusterContactPoint, port);
+        this.cluster = cassJavaDriverManager.registerCluster(ClusterName,ClusterContactPoint,connections,port);
         this.session = cassJavaDriverManager.getSession(cluster);
 
         upsertKeyspace(this.session);
@@ -105,7 +107,8 @@ public abstract class CJavaDriverBasePlugin implements NdBenchClient {
 
    protected void upsertGenereicKeyspace()
    {
-       session.execute("CREATE KEYSPACE IF NOT EXISTS " +KeyspaceName+" WITH replication = {'class': 'NetworkTopologyStrategy','eu-west': '3','us-east': '3'};");
+       System.out.println(Replication);
+       session.execute("CREATE KEYSPACE IF NOT EXISTS " +KeyspaceName+" WITH replication = " +Replication+ ";");
        session.execute("Use " + KeyspaceName);
    }
 }

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverManager.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverManager.java
@@ -5,6 +5,9 @@ package com.netflix.ndbench.plugin.cass;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.policies.*;
 import com.google.inject.ImplementedBy;
 
 /**
@@ -12,7 +15,7 @@ import com.google.inject.ImplementedBy;
  */
 @ImplementedBy(CassJavaDriverManagerImpl.class)
 public interface CassJavaDriverManager {
-    Cluster registerCluster(String clName, String contactPoint, int port);
+    Cluster registerCluster(String clName, String contactPoint, int connections, int port);
 
     Session getSession(Cluster cluster);
 

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverManagerImpl.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassJavaDriverManagerImpl.java
@@ -5,6 +5,10 @@ package com.netflix.ndbench.plugin.cass;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.PoolingOptions;
+import com.datastax.driver.core.HostDistance;
+import com.datastax.driver.core.policies.*;
+
 
 /**
  * @author vchella
@@ -15,11 +19,18 @@ public class CassJavaDriverManagerImpl implements CassJavaDriverManager {
     Session session;
 
     @Override
-    public Cluster registerCluster(String clName, String contactPoint, int port) {
+    public Cluster registerCluster(String clName, String contactPoint, int connections, int port) {
+    
+        PoolingOptions poolingOpts = new PoolingOptions()
+                                     .setConnectionsPerHost(HostDistance.LOCAL, connections, connections)
+                                     .setMaxRequestsPerConnection(HostDistance.LOCAL, 32768);
+    
         cluster = Cluster.builder()
                 .withClusterName(clName)
                 .addContactPoint(contactPoint)
+                .withPoolingOptions(poolingOpts)
                 .withPort(port)
+                .withLoadBalancingPolicy( new TokenAwarePolicy( new RoundRobinPolicy() ) )
                 .build();
         return cluster;
     }

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/defaultimpl/NdBenchGuiceModule.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public class NdBenchGuiceModule extends AbstractModule {
     private static final org.slf4j.Logger Logger = LoggerFactory.getLogger(NdBenchGuiceModule.class);
 
-    
+
     @Override
     protected void configure() {
         bind(NdBenchMonitor.class).to(FakeMonitor.class);
@@ -47,7 +47,10 @@ public class NdBenchGuiceModule extends AbstractModule {
             bind(IClusterDiscovery.class).to(AWSLocalClusterDiscovery.class);
         } else if (discoveryEnv != null && discoveryEnv.equals(NdBenchConstants.DISCOVERY_ENV_AWS_ASG)) {
             bind(IClusterDiscovery.class).to(AwsAsgDiscovery.class);
-        } else {
+        } else if (discoveryEnv != null && discoveryEnv.equals(NdBenchConstants.DISCOVERY_ENV_AWS_CONFIG_FILE)) {
+            bind(IClusterDiscovery.class).to(ConfigFileDiscovery.class);
+        }
+          else {
             bind(IClusterDiscovery.class).to(LocalClusterDiscovery.class);
         }
         bind(DataGenerator.class).to(DefaultDataGenerator.class);


### PR DESCRIPTION
Config file discovery exists but it is not enabled in  NdBenchGuiceModule.java class or have a variable assigned in NdBenchConstants.java

This commit enables config file discovery and creates a DISCOVERY_ENV (CONFIG_FILE) variable to enable it during build. 