### PR TITLE
Enable autoscaling when using programmatic tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ bin/
 *.iws
 .idea/*
 *.log
+ndbench-cass-plugins/out/
+ndbench-cli/src/test/
+ndbench-core/out/

--- a/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/common/NdBenchConstants.java
+++ b/ndbench-api/src/main/java/com/netflix/ndbench/api/plugin/common/NdBenchConstants.java
@@ -22,7 +22,7 @@ package com.netflix.ndbench.api.plugin.common;
  */
 public final class NdBenchConstants {
     public static final String WEBAPP_NAME = "ndbench";
-    public static final String PROP_NAMESPACE =  (WEBAPP_NAME + ".config") + ".";
+    public static final String PROP_NAMESPACE = (WEBAPP_NAME + ".config") + ".";
 
     public static final String NUM_KEYS="numKeys";
     public static final String NUM_VALUES="numValues";

--- a/ndbench-cli/build.gradle
+++ b/ndbench-cli/build.gradle
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+apply plugin: 'java'
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':ndbench-core')
+    compile project(':ndbench-api')
+    compile project(':ndbench-cass-plugins')
+    compile project(':ndbench-dynamodb-plugins')
+    compile project(':ndbench-dyno-plugins')
+    compile project(':ndbench-es-plugins')
+    //compile project(':ndbench-evcache-plugins')
+    compile project(':ndbench-geode-plugins')
+    compile project(':ndbench-janusgraph-plugins')
+    compile project(':ndbench-sample-plugins')
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+}
+
+task run (type: JavaExec, dependsOn: classes){
+    systemProperties System.properties
+    main = "com.netflix.ndbench.cli.NdbenchCli"
+    classpath = sourceSets.main.runtimeClasspath
+}

--- a/ndbench-cli/src/main/java/com/netflix/ndbench/cli/CliModule.java
+++ b/ndbench-cli/src/main/java/com/netflix/ndbench/cli/CliModule.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2018 Netflix, Inc.
+ *  Copyright 2016 Netflix, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,30 +14,29 @@
  *  limitations under the License.
  *
  */
-package com.netflix.ndbench.plugin.dynamodb.configs;
+package com.netflix.ndbench.cli;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPluginGuiceModule;
-import com.netflix.ndbench.plugin.dynamodb.NdbenchAWSCredentialProvider;
+import com.netflix.ndbench.cli.config.CliConfigs;
 
 /**
- * 
- * @author ipapapa
+ * This Module allows Guice to inject archaius configuration for the CLI
  *
+ * @author Alexander Patrikalakis
  */
 @NdBenchClientPluginGuiceModule
-public class DynamoDBModule extends AbstractModule {
+public class CliModule extends AbstractModule {
 
     @Override
     protected void configure() {
-        bind(AWSCredentialsProvider.class).to(NdbenchAWSCredentialProvider.class);
     }
 
     @Provides
-    DynamoDBConfigs getDynamoDBConfigs(ConfigProxyFactory factory) {
-        return factory.newProxy(DynamoDBConfigs.class);
+    CliConfigs getCliConfigs(ConfigProxyFactory factory) {
+        return factory.newProxy(CliConfigs.class);
     }
+
 }

--- a/ndbench-cli/src/main/java/com/netflix/ndbench/cli/NdbenchCli.java
+++ b/ndbench-cli/src/main/java/com/netflix/ndbench/cli/NdbenchCli.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2018 Netflix
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.netflix.ndbench.cli;
+
+import com.google.inject.Injector;
+import com.netflix.ndbench.cli.config.CliConfigs;
+import com.netflix.ndbench.core.NdBenchClientFactory;
+import com.netflix.ndbench.core.NdBenchDriver;
+import com.netflix.ndbench.core.config.GuiceInjectorProvider;
+import com.netflix.ndbench.core.util.LoadPattern;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is a CLI entry point to facilitate quick testing of the Netflix Database Benchmark.
+ * In particular, this class does not require deploying a WAR to Tomcat to run the benchmark.
+ * Nor does this class require running a Context in a web container.
+ *
+ * @author Alexander Patrikalakis
+ */
+public class NdbenchCli {
+    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(NdbenchCli.class);
+    public static void main(final String[] argv) {
+        Injector injector = new GuiceInjectorProvider().getInjector(new CliModule());
+        CliConfigs cliConfigs = injector.getInstance(CliConfigs.class);
+        NdBenchDriver driver = injector.getInstance(NdBenchDriver.class);
+
+        try {
+            driver.init(injector.getInstance(NdBenchClientFactory.class).getClient(cliConfigs.getClientName()));
+            logger.info("Starting driver in CLI with loadPattern=" + cliConfigs.getLoadPattern()
+                    + ", windowSize=" + cliConfigs.getWindowSize()
+                    + ", windowDurationInSec=" + cliConfigs.getWindowDurationInSec()
+                    + ", bulkSize=" + cliConfigs.getBulkSize()
+                    + ", timeout(ms)=" + cliConfigs.getCliTimeoutMillis()
+                    + ", clientName=" + cliConfigs.getClientName());
+            driver.start(
+                    LoadPattern.fromString(cliConfigs.getLoadPattern()),
+                    Integer.valueOf(cliConfigs.getWindowSize()),
+                    Integer.valueOf(cliConfigs.getWindowDurationInSec()),
+                    Integer.valueOf(cliConfigs.getBulkSize())
+            );
+            long millisToWait = Integer.valueOf(cliConfigs.getCliTimeoutMillis());
+            logger.info("Waiting " + millisToWait + " ms for reads and writes to finish");
+            Thread.sleep(millisToWait); //blocking
+            logger.info("Waited " + millisToWait + " ms for reads and writes to finish. Stopping driver.");
+            driver.stop(); //blocking
+            logger.info("Stopped driver");
+            System.exit(0);
+        } catch(Exception e) {
+            logger.error("Encountered an exception when driving load", e);
+            System.exit(-1);
+        }
+    }
+}

--- a/ndbench-cli/src/main/java/com/netflix/ndbench/cli/config/CliConfigs.java
+++ b/ndbench-cli/src/main/java/com/netflix/ndbench/cli/config/CliConfigs.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2016 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.netflix.ndbench.cli.config;
+
+import com.netflix.archaius.api.annotations.Configuration;
+import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.archaius.api.annotations.PropertyName;
+import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
+
+/**
+ * This class contains configuration for the CLI.
+ * The CLI can pull this configuration from environment variables or from system properties.
+ *
+ * @author Alexander Patrikalakis
+ */
+@Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE +  "cli")
+public interface CliConfigs {
+    @PropertyName(name = "bulkSize")
+    @DefaultValue("1")
+    String getBulkSize();
+
+    @PropertyName(name = "timeoutMillis")
+    @DefaultValue("360000")
+    String getCliTimeoutMillis();
+
+    @PropertyName(name = "loadPattern")
+    @DefaultValue("random")
+    String getLoadPattern();
+
+    @PropertyName(name = "windowSize")
+    @DefaultValue("-1")
+    String getWindowSize();
+
+    @PropertyName(name = "windowDurationInSec")
+    @DefaultValue("-1")
+    String getWindowDurationInSec();
+
+    @PropertyName(name = "clientName")
+    @DefaultValue("InMemoryTest")
+    String getClientName();
+}

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/NdBenchDriver.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/NdBenchDriver.java
@@ -19,7 +19,9 @@ package com.netflix.ndbench.core;
 
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
+import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.api.inject.RuntimeLayer;
 import com.netflix.ndbench.api.plugin.DataGenerator;
@@ -115,7 +117,6 @@ public class NdBenchDriver {
             }
         });
     }
-
 
     public void start(LoadPattern loadPattern, int windowSize, long windowDurationInSec, int bulkSize) {
         logger.info("Starting Load Test Driver...");

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
@@ -24,7 +24,7 @@ import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
 /**
  * @author vchella
  */
-@Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE)
+@Configuration(prefix = NdBenchConstants.PROP_NAMESPACE)
 public interface IConfiguration {
 
     void initialize();

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/generators/RandomStringKeyGenerator.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/generators/RandomStringKeyGenerator.java
@@ -31,7 +31,7 @@ public class RandomStringKeyGenerator extends StringKeyGenerator {
 
     @Override
     public String getNextKey() {
-        int randomKeyIndex = kRandom.nextInt(getNumKeys());
+        int randomKeyIndex = kRandom.nextInt(numKeys);
         if (isPreLoadKeys()) {
             return keys.get(randomKeyIndex);
         } else {

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/generators/StringKeyGenerator.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/generators/StringKeyGenerator.java
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public abstract class StringKeyGenerator implements KeyGenerator<String> {
     private static Logger logger = LoggerFactory.getLogger(StringKeyGenerator.class);

--- a/ndbench-dynamodb-plugins/build.gradle
+++ b/ndbench-dynamodb-plugins/build.gradle
@@ -1,7 +1,7 @@
 repositories {
-   flatDir {
-       dirs buildDir
-   }
+    flatDir {
+        dirs buildDir
+    }
 }
 
 
@@ -14,8 +14,7 @@ dependencies {
         dest buildDir
         overwrite false
     }
-    
-    compileOnly name: 'DaxJavaClient-latest'
-        
-}
 
+    compileOnly name: 'DaxJavaClient-latest'
+
+}

--- a/ndbench-dynamodb-plugins/build.gradle
+++ b/ndbench-dynamodb-plugins/build.gradle
@@ -8,6 +8,8 @@ repositories {
 dependencies {
     compile project(':ndbench-api')
     compile "com.amazonaws:aws-java-sdk-dynamodb:latest.release"
+    compile "com.amazonaws:aws-java-sdk-applicationautoscaling:latest.release"
+    compile "com.amazonaws:aws-java-sdk-sts:latest.release"
 
     download {
         src 'http://dax-sdk.s3-website-us-west-2.amazonaws.com/java/DaxJavaClient-latest.jar'

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBAutoscalingConfigurer.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBAutoscalingConfigurer.java
@@ -1,0 +1,189 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.netflix.ndbench.plugin.dynamodb;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScaling;
+import com.amazonaws.services.applicationautoscaling.AWSApplicationAutoScalingClientBuilder;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalableTargetsRequest;
+import com.amazonaws.services.applicationautoscaling.model.DescribeScalingPoliciesRequest;
+import com.amazonaws.services.applicationautoscaling.model.MetricType;
+import com.amazonaws.services.applicationautoscaling.model.PolicyType;
+import com.amazonaws.services.applicationautoscaling.model.PredefinedMetricSpecification;
+import com.amazonaws.services.applicationautoscaling.model.PutScalingPolicyRequest;
+import com.amazonaws.services.applicationautoscaling.model.RegisterScalableTargetRequest;
+import com.amazonaws.services.applicationautoscaling.model.ScalableDimension;
+import com.amazonaws.services.applicationautoscaling.model.ServiceNamespace;
+import com.amazonaws.services.applicationautoscaling.model.TargetTrackingScalingPolicyConfiguration;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsResult;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+@Singleton
+public class DynamoDBAutoscalingConfigurer {
+    private static final int DEFAULT_SCALE_IN_OUT_COOLDOWN = 60;
+
+    private final AWSApplicationAutoScaling autoScalingClient;
+    private final AWSSecurityTokenService securityTokenService;
+
+    @Inject
+    public DynamoDBAutoscalingConfigurer(final AWSCredentialsProvider awsCredentialsProvider) {
+        autoScalingClient = AWSApplicationAutoScalingClientBuilder.standard()
+                .withCredentials(awsCredentialsProvider)
+                .build();
+        securityTokenService = AWSSecurityTokenServiceClientBuilder.standard()
+                .withCredentials(awsCredentialsProvider)
+                .build();
+    }
+
+    /**
+     * configure autoscaling as per aws docs:
+     * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/AutoScaling.HowTo.SDK.html
+     * @param readCapacityUnits
+     * @param writeCapacityUnits
+     * @param tableName
+     * @param limits
+     * @param targetWriteUtilization
+     * @param targetReadUtilization
+     */
+    public void setupAutoscaling(Long readCapacityUnits,
+                                  Long writeCapacityUnits,
+                                  String tableName,
+                                  DescribeLimitsResult limits,
+                                  Integer targetWriteUtilization,
+                                  Integer targetReadUtilization) {
+        String resourceID = "table/" + tableName;
+        String accountId = securityTokenService.getCallerIdentity(new GetCallerIdentityRequest()).getAccount();
+        String serviceRoleArn = "arn:aws:iam::" + accountId
+                + ":role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_"
+                + tableName;
+        createAndVerifyScalableTargetAndScalingPolicy(serviceRoleArn,
+                resourceID,
+                ScalableDimension.DynamodbTableWriteCapacityUnits,
+                MetricType.DynamoDBWriteCapacityUtilization,
+                writeCapacityUnits,
+                limits.getTableMaxWriteCapacityUnits().intValue(),
+                targetWriteUtilization);
+        createAndVerifyScalableTargetAndScalingPolicy(serviceRoleArn,
+                resourceID,
+                ScalableDimension.DynamodbTableReadCapacityUnits,
+                MetricType.DynamoDBReadCapacityUtilization,
+                readCapacityUnits,
+                limits.getTableMaxReadCapacityUnits().intValue(),
+                targetReadUtilization);
+    }
+
+    private void createAndVerifyScalableTargetAndScalingPolicy(String serviceRoleArn,
+                                                               String resourceID,
+                                                               ScalableDimension scalableDimension,
+                                                               MetricType metricType,
+                                                               Long capacityUnits,
+                                                               Integer maxCapacityUnits,
+                                                               Integer utilizationTarget) {
+        createAndVerifyScalableTarget(resourceID, serviceRoleArn, scalableDimension, capacityUnits.intValue(),
+                maxCapacityUnits);
+        createAndVerifyScalingPolicy(resourceID, scalableDimension, metricType, utilizationTarget.doubleValue());
+    }
+
+    private void createAndVerifyScalingPolicy(final String resourceID,
+                                              final ScalableDimension scalableDimension,
+                                              final MetricType metricType,
+                                              final Double targetValue) {
+        // Configure a scaling policy
+        TargetTrackingScalingPolicyConfiguration targetTrackingScalingPolicyConfiguration =
+                new TargetTrackingScalingPolicyConfiguration()
+                        .withPredefinedMetricSpecification(new PredefinedMetricSpecification().withPredefinedMetricType(metricType))
+                        .withTargetValue(targetValue)
+                        .withScaleInCooldown(DEFAULT_SCALE_IN_OUT_COOLDOWN)
+                        .withScaleOutCooldown(DEFAULT_SCALE_IN_OUT_COOLDOWN);
+
+        // Create the scaling policy, based on your configuration
+        PutScalingPolicyRequest pspRequest = new PutScalingPolicyRequest()
+                .withServiceNamespace(ServiceNamespace.Dynamodb)
+                .withScalableDimension(scalableDimension)
+                .withResourceId(resourceID)
+                .withPolicyName("My" + scalableDimension.name() + "ScalingPolicy")
+                .withPolicyType(PolicyType.TargetTrackingScaling)
+                .withTargetTrackingScalingPolicyConfiguration(targetTrackingScalingPolicyConfiguration);
+
+        final String scalingPolicyArn;
+        try {
+            scalingPolicyArn = autoScalingClient.putScalingPolicy(pspRequest).getPolicyARN();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to put scaling policy", e);
+        }
+
+        // Verify that the scaling policy was created
+        DescribeScalingPoliciesRequest dspRequest = new DescribeScalingPoliciesRequest()
+                .withServiceNamespace(ServiceNamespace.Dynamodb)
+                .withScalableDimension(scalableDimension)
+                .withResourceId(resourceID);
+
+        try {
+            autoScalingClient.describeScalingPolicies(dspRequest).getScalingPolicies().stream()
+                    .filter(scalingPolicy -> scalingPolicy.getPolicyARN().equals(scalingPolicyArn))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Scaling policy was created but arn did not match"));
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to verify scaling policy", e);
+        }
+    }
+
+    private void createAndVerifyScalableTarget(final String resourceID,
+                                               final String serviceRoleArn,
+                                               final ScalableDimension scalableDimension,
+                                               final Integer minimumCapacity,
+                                               final Integer maximumCapacity) {
+        // Define the scalable targets
+        RegisterScalableTargetRequest rstRequest = new RegisterScalableTargetRequest()
+                .withServiceNamespace(ServiceNamespace.Dynamodb)
+                .withResourceId(resourceID)
+                .withScalableDimension(scalableDimension)
+                .withMinCapacity(minimumCapacity)
+                .withMaxCapacity(maximumCapacity)
+                .withRoleARN(serviceRoleArn);
+
+        try {
+            autoScalingClient.registerScalableTarget(rstRequest);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to register scalable target", e);
+        }
+
+        // Verify that the target was created
+        // note that scalable targets do not have arns of their own so need to verify the contents
+        DescribeScalableTargetsRequest dscRequest = new DescribeScalableTargetsRequest()
+                .withServiceNamespace(ServiceNamespace.Dynamodb)
+                .withScalableDimension(scalableDimension)
+                .withResourceIds(resourceID);
+        try {
+            autoScalingClient.describeScalableTargets(dscRequest).getScalableTargets().stream()
+                    .filter(target -> target.getResourceId().equals(resourceID)
+                            && target.getScalableDimension().equals(scalableDimension.toString())
+                            && target.getServiceNamespace().equals(ServiceNamespace.Dynamodb.toString())
+                            && target.getMinCapacity().equals(minimumCapacity)
+                            && target.getMaxCapacity().equals(maximumCapacity)
+                            && target.getRoleARN().equals(serviceRoleArn))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Target was created but not all fields matched"));
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to verify scalable target", e);
+        }
+    }
+}

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBKeyValue.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBKeyValue.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazon.dax.client.dynamodbv2.AmazonDaxClientBuilder;
-import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/configs/DynamoDBConfigs.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/configs/DynamoDBConfigs.java
@@ -47,12 +47,27 @@ public interface DynamoDBConfigs {
      * Used for provisioned throughput
      */
     @PropertyName(name = "rcu")
-    @DefaultValue("2")
+    @DefaultValue("5")
     String getReadCapacityUnits();
 
     @PropertyName(name = "wcu")
-    @DefaultValue("2")
+    @DefaultValue("5")
     String getWriteCapacityUnits();
+
+    /*
+     * Application Autoscaling for DynamoDB
+     */
+    @PropertyName(name = "autoscaling")
+    @DefaultValue("true")
+    Boolean getAutoscaling();
+
+    @PropertyName(name = "targetReadUtilization")
+    @DefaultValue("70")
+    String getTargetReadUtilization();
+
+    @PropertyName(name = "targetWriteUtilization")
+    @DefaultValue("70")
+    String getTargetWriteUtilization();
 
     /*
      * Consistency: When you request a strongly consistent read, DynamoDB returns a

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/configs/DynamoDBConfigs.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/configs/DynamoDBConfigs.java
@@ -27,7 +27,7 @@ import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
  *
  * @author ipapapa
  */
-@Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE +  "dynamodb")
+@Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE + "dynamodb")
 public interface DynamoDBConfigs {
 
     @PropertyName(name = "tablename")

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/AbstractDynamoDBOperation.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/AbstractDynamoDBOperation.java
@@ -43,7 +43,7 @@ public abstract class AbstractDynamoDBOperation {
         this.partitionKeyName = partitionKeyName;
     }
 
-    protected void amazonServiceException(AmazonServiceException ase) {
+    protected AmazonServiceException amazonServiceException(AmazonServiceException ase) {
         logger.error("Caught an AmazonServiceException, which means your request made it "
                 + "to AWS, but was rejected with an error response for some reason.");
         logger.error("Error Message:    " + ase.getMessage());
@@ -51,12 +51,14 @@ public abstract class AbstractDynamoDBOperation {
         logger.error("AWS Error Code:   " + ase.getErrorCode());
         logger.error("Error Type:       " + ase.getErrorType());
         logger.error("Request ID:       " + ase.getRequestId());
+        return ase;
     }
 
-    protected void amazonClientException(AmazonClientException ace) {
+    protected AmazonClientException amazonClientException(AmazonClientException ace) {
         logger.error("Caught an AmazonClientException, which means the client encountered "
                 + "a serious internal problem while trying to communicate with AWS, "
                 + "such as not being able to access the network.");
         logger.error("Error Message: " + ace.getMessage());
+        return ace;
     }
 }

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/controlplane/CreateDynamoDBTable.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/controlplane/CreateDynamoDBTable.java
@@ -17,6 +17,7 @@
 package com.netflix.ndbench.plugin.dynamodb.operations.controlplane;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
@@ -88,8 +89,10 @@ public class CreateDynamoDBTable extends AbstractDynamoDBOperation implements Su
             logger.debug("Waiting until the table is in ACTIVE state");
             TableUtils.waitUntilActive(dynamoDB, tableName);
             return dynamoDB.describeTable(tableName).getTable();
-        } catch (AmazonClientException e) {
-            throw new IllegalStateException("Table didn't become active", e);
+        } catch (AmazonServiceException ase) {
+            throw amazonServiceException(ase);
+        } catch (AmazonClientException ace) {
+            throw amazonClientException(ace);
         } catch (InterruptedException e) {
             throw new IllegalStateException("Table interrupted exception", e);
         }

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/controlplane/DescribeLimits.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/controlplane/DescribeLimits.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.netflix.ndbench.plugin.dynamodb.operations.controlplane;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsResult;
+import com.netflix.ndbench.plugin.dynamodb.operations.AbstractDynamoDBOperation;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Alexander Patrikalakis
+ */
+public class DescribeLimits extends AbstractDynamoDBOperation implements Supplier<DescribeLimitsResult> {
+    public DescribeLimits(AmazonDynamoDB dynamoDB, String tableName, String partitionKeyName) {
+        super(dynamoDB, tableName, partitionKeyName);
+    }
+
+    @Override
+    public DescribeLimitsResult get() {
+        return dynamoDB.describeLimits(new DescribeLimitsRequest());
+    }
+}

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/dataplane/DynamoDBReadBulk.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/dataplane/DynamoDBReadBulk.java
@@ -53,11 +53,9 @@ public class DynamoDBReadBulk extends AbstractDynamoDBReadOperation implements F
                     .map(Map::toString)
                     .collect(Collectors.toList());
         } catch (AmazonServiceException ase) {
-            amazonServiceException(ase);
-            throw ase;
+            throw amazonServiceException(ase);
         } catch (AmazonClientException ace) {
-            amazonClientException(ace);
-            throw ace;
+            throw amazonClientException(ace);
         }
     }
 

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/dataplane/DynamoDBReadSingle.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/dataplane/DynamoDBReadSingle.java
@@ -48,11 +48,9 @@ public class DynamoDBReadSingle extends AbstractDynamoDBReadOperation implements
                     .map(Map::toString)
                     .orElse(null);
         } catch (AmazonServiceException ase) {
-            amazonServiceException(ase);
-            throw ase;
+            throw amazonServiceException(ase);
         } catch (AmazonClientException ace) {
-            amazonClientException(ace);
-            throw ace;
+            throw amazonClientException(ace);
         }
     }
 }

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/dataplane/DynamoDBWriteBulk.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/dataplane/DynamoDBWriteBulk.java
@@ -54,11 +54,9 @@ public class DynamoDBWriteBulk extends AbstractDynamoDBDataPlaneOperation implem
                     .map(PutRequest::toString)
                     .collect(Collectors.toList());
         } catch (AmazonServiceException ase) {
-            amazonServiceException(ase);
-            throw ase;
+            throw amazonServiceException(ase);
         } catch (AmazonClientException ace) {
-            amazonClientException(ace);
-            throw ace;
+            throw amazonClientException(ace);
         }
     }
 

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/dataplane/DynamoDBWriteSingle.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/operations/dataplane/DynamoDBWriteSingle.java
@@ -45,11 +45,9 @@ public class DynamoDBWriteSingle extends AbstractDynamoDBDataPlaneOperation impl
                     .addItemEntry(ATTRIBUTE_NAME, new AttributeValue().withS(dataGenerator.getRandomValue())));
             return outcome == null ? null : outcome.toString();
         } catch (AmazonServiceException ase) {
-            amazonServiceException(ase);
-            throw ase;
+            throw amazonServiceException(ase);
         } catch (AmazonClientException ace) {
-            amazonClientException(ace);
-            throw ace;
+            throw amazonClientException(ace);
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,9 @@
 rootProject.name='ndbench'
 
 include 'ndbench-api'
-include 'ndbench-core'
 include 'ndbench-cass-plugins'
+include 'ndbench-cli'
+include 'ndbench-core'
 include 'ndbench-dynamodb-plugins'
 include 'ndbench-dyno-plugins'
 include 'ndbench-es-plugins'


### PR DESCRIPTION
Fixes #131 

I use default values present in the AWS console for all numbers (initial r/w CU, minimum r/w CU, maximum r/w CU and target r/w utilization).