### PR TITLE
Add some code verification tests to the programmatic DynamoDB module

### DIFF
--- a/ndbench-dynamodb-plugins/build.gradle
+++ b/ndbench-dynamodb-plugins/build.gradle
@@ -1,3 +1,9 @@
+repositories {
+    maven {
+        url 'https://s3-us-west-2.amazonaws.com/dynamodb-local/release'
+    }
+}
+
 apply plugin: "jacoco"
 
 jacoco {
@@ -30,5 +36,22 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-cloudwatch:latest.release"
     testCompile group: 'com.netflix.archaius', name: 'archaius2-guice', version: '2.1.11'
     testCompile 'com.netflix.governator:governator-test-junit:[1.15.3,)'
+    testCompile project(':ndbench-core')
+    testCompile 'com.amazonaws:DynamoDBLocal:[1.11,2.0)'
 
+}
+
+task copyNativeDeps(type: Copy) {
+    from (configurations.testCompile) {
+        include "*.dylib"
+        include "*.so"
+        include "*.dll"
+    }
+    into 'build/libs'
+}
+
+test.dependsOn copyNativeDeps
+test.doFirst {
+    systemProperty "java.library.path", 'build/libs'
+    systemProperty "sqlite4java.library.path", 'build/libs'
 }

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBKeyValue.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBKeyValue.java
@@ -56,7 +56,6 @@ import static com.amazonaws.retry.PredefinedRetryPolicies.NO_RETRY_POLICY;
 @NdBenchClientPlugin("DynamoDBKeyValue")
 public class DynamoDBKeyValue extends DynamoDBKeyValueBase<DynamoDBConfiguration> implements NdBenchClient {
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBKeyValue.class);
-    private static final boolean DO_HONOR_MAX_ERROR_RETRY_IN_CLIENT_CONFIG = true;
 
     /**
      * Public constructor to inject credentials and configuration
@@ -73,42 +72,8 @@ public class DynamoDBKeyValue extends DynamoDBKeyValueBase<DynamoDBConfiguration
     public void init(DataGenerator dataGenerator) {
         logger.info("Initializing AWS SDK clients");
 
-        // build dynamodb client
-        AmazonDynamoDBClientBuilder dynamoDbBuilder = AmazonDynamoDBClientBuilder.standard();
-        dynamoDbBuilder.withClientConfiguration(new ClientConfiguration()
-                .withMaxConnections(config.getMaxConnections())
-                .withRequestTimeout(config.getMaxRequestTimeout()) //milliseconds
-                .withRetryPolicy(config.getMaxRetries() <= 0 ? NO_RETRY_POLICY : new RetryPolicy(DEFAULT_RETRY_CONDITION,
-                        DYNAMODB_DEFAULT_BACKOFF_STRATEGY,
-                        config.getMaxRetries(),
-                        DO_HONOR_MAX_ERROR_RETRY_IN_CLIENT_CONFIG))
-                .withGzip(config.isCompressing()));
-        dynamoDbBuilder.withCredentials(awsCredentialsProvider);
-        if (StringUtils.isNotEmpty(this.config.getEndpoint())) {
-            Preconditions.checkState(StringUtils.isNotEmpty(config.getRegion()),
-                    "If you set the endpoint you must set the region");
-            dynamoDbBuilder.withEndpointConfiguration(
-                    new AwsClientBuilder.EndpointConfiguration(config.getEndpoint(), config.getRegion()));
-        }
-        dynamoDB = dynamoDbBuilder.build();
-
-        //instantiate operations
-        String tableName = config.getTableName();
-        String partitionKeyName = config.getAttributeName();
-        ReturnConsumedCapacity returnConsumedCapacity = ReturnConsumedCapacity.NONE;
-        Preconditions.checkState(StringUtils.isNotEmpty(tableName));
-        Preconditions.checkState(StringUtils.isNotEmpty(partitionKeyName));
-
-        //data plane
-        boolean consistentRead = config.consistentRead();
-        this.singleRead = new DynamoDBReadSingle(dataGenerator, dynamoDB, tableName, partitionKeyName, consistentRead,
-                returnConsumedCapacity);
-        this.bulkRead = new DynamoDBReadBulk(dataGenerator, dynamoDB, tableName, partitionKeyName, consistentRead,
-                returnConsumedCapacity);
-        this.singleWrite = new DynamoDBWriteSingle(dataGenerator, dynamoDB, tableName, partitionKeyName,
-                returnConsumedCapacity);
-        this.bulkWrite = new DynamoDBWriteBulk(dataGenerator, dynamoDB, tableName, partitionKeyName,
-                returnConsumedCapacity);
+        createAndSetDynamoDBClient();
+        instantiateDataPlaneOperations(dataGenerator);
 
         logger.info("DynamoDB Plugin initialized");
     }
@@ -128,13 +93,5 @@ public class DynamoDBKeyValue extends DynamoDBKeyValueBase<DynamoDBConfiguration
 
     AmazonDynamoDB getDynamoDB() {
         return this.dynamoDB;
-    }
-
-    double getAndResetReadCounsumed() {
-        return singleRead.getAndResetConsumed() + bulkRead.getAndResetConsumed();
-    }
-
-    double getAndResetWriteCounsumed() {
-        return singleWrite.getAndResetConsumed() + bulkWrite.getAndResetConsumed();
     }
 }

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBKeyValueBase.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBKeyValueBase.java
@@ -16,8 +16,14 @@
  */
 package com.netflix.ndbench.plugin.dynamodb;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity;
+import com.google.common.base.Preconditions;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.plugin.dynamodb.configs.DynamoDBConfigurationBase;
@@ -25,16 +31,22 @@ import com.netflix.ndbench.plugin.dynamodb.operations.dynamodb.dataplane.DynamoD
 import com.netflix.ndbench.plugin.dynamodb.operations.dynamodb.dataplane.DynamoDBReadSingle;
 import com.netflix.ndbench.plugin.dynamodb.operations.dynamodb.dataplane.DynamoDBWriteBulk;
 import com.netflix.ndbench.plugin.dynamodb.operations.dynamodb.dataplane.DynamoDBWriteSingle;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+
+import static com.amazonaws.retry.PredefinedRetryPolicies.DEFAULT_RETRY_CONDITION;
+import static com.amazonaws.retry.PredefinedRetryPolicies.DYNAMODB_DEFAULT_BACKOFF_STRATEGY;
+import static com.amazonaws.retry.PredefinedRetryPolicies.NO_RETRY_POLICY;
 
 /**
  * Base class with shared fields among the various implementations of NdBenchClient.
  */
 public abstract class DynamoDBKeyValueBase<C extends DynamoDBConfigurationBase> implements NdBenchClient {
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBKeyValueBase.class);
+    private static final boolean DO_HONOR_MAX_ERROR_RETRY_IN_CLIENT_CONFIG = true;
 
     protected final AWSCredentialsProvider awsCredentialsProvider;
     protected final C config;
@@ -55,6 +67,46 @@ public abstract class DynamoDBKeyValueBase<C extends DynamoDBConfigurationBase> 
                                    C configuration) {
         this.awsCredentialsProvider = awsCredentialsProvider;
         this.config = configuration;
+    }
+
+    protected void instantiateDataPlaneOperations(DataGenerator dataGenerator) {
+        //instantiate operations
+        String tableName = config.getTableName();
+        String partitionKeyName = config.getAttributeName();
+        ReturnConsumedCapacity returnConsumedCapacity = ReturnConsumedCapacity.NONE;
+        Preconditions.checkState(StringUtils.isNotEmpty(tableName));
+        Preconditions.checkState(StringUtils.isNotEmpty(partitionKeyName));
+
+        //data plane
+        boolean consistentRead = config.consistentRead();
+        this.singleRead = new DynamoDBReadSingle(dataGenerator, dynamoDB, tableName, partitionKeyName, consistentRead,
+                returnConsumedCapacity);
+        this.bulkRead = new DynamoDBReadBulk(dataGenerator, dynamoDB, tableName, partitionKeyName, consistentRead,
+                returnConsumedCapacity);
+        this.singleWrite = new DynamoDBWriteSingle(dataGenerator, dynamoDB, tableName, partitionKeyName,
+                returnConsumedCapacity);
+        this.bulkWrite = new DynamoDBWriteBulk(dataGenerator, dynamoDB, tableName, partitionKeyName,
+                returnConsumedCapacity);
+    }
+
+    protected void createAndSetDynamoDBClient() {
+        AmazonDynamoDBClientBuilder dynamoDbBuilder = AmazonDynamoDBClientBuilder.standard();
+        dynamoDbBuilder.withClientConfiguration(new ClientConfiguration()
+                .withMaxConnections(config.getMaxConnections())
+                .withRequestTimeout(config.getMaxRequestTimeout()) //milliseconds
+                .withRetryPolicy(config.getMaxRetries() <= 0 ? NO_RETRY_POLICY : new RetryPolicy(DEFAULT_RETRY_CONDITION,
+                        DYNAMODB_DEFAULT_BACKOFF_STRATEGY,
+                        config.getMaxRetries(),
+                        DO_HONOR_MAX_ERROR_RETRY_IN_CLIENT_CONFIG))
+                .withGzip(config.isCompressing()));
+        dynamoDbBuilder.withCredentials(awsCredentialsProvider);
+        if (StringUtils.isNotEmpty(this.config.getEndpoint())) {
+            Preconditions.checkState(StringUtils.isNotEmpty(config.getRegion()),
+                    "If you set the endpoint you must set the region");
+            dynamoDbBuilder.withEndpointConfiguration(
+                    new AwsClientBuilder.EndpointConfiguration(config.getEndpoint(), config.getRegion()));
+        }
+        this.dynamoDB = dynamoDbBuilder.build();
     }
 
     @Override
@@ -96,5 +148,13 @@ public abstract class DynamoDBKeyValueBase<C extends DynamoDBConfigurationBase> 
     @Override
     public String runWorkFlow() {
         return null;
+    }
+
+    double getAndResetReadCounsumed() {
+        return singleRead.getAndResetConsumed() + bulkRead.getAndResetConsumed();
+    }
+
+    double getAndResetWriteCounsumed() {
+        return singleWrite.getAndResetConsumed() + bulkWrite.getAndResetConsumed();
     }
 }

--- a/ndbench-dynamodb-plugins/src/test/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBProgrammaticKeyValueTest.java
+++ b/ndbench-dynamodb-plugins/src/test/java/com/netflix/ndbench/plugin/dynamodb/DynamoDBProgrammaticKeyValueTest.java
@@ -1,0 +1,89 @@
+package com.netflix.ndbench.plugin.dynamodb;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
+import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
+import com.netflix.archaius.guice.ArchaiusModule;
+import com.netflix.archaius.test.TestPropertyOverride;
+import com.netflix.governator.guice.test.ModulesForTesting;
+import com.netflix.governator.guice.test.junit4.GovernatorJunit4ClassRunner;
+import com.netflix.ndbench.core.defaultimpl.NdBenchGuiceModule;
+import com.netflix.ndbench.core.generators.DefaultDataGenerator;
+import com.netflix.ndbench.plugin.dynamodb.configs.DynamoDBModule;
+import com.netflix.ndbench.plugin.dynamodb.configs.ProgrammaticDynamoDBConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GovernatorJunit4ClassRunner.class)
+@ModulesForTesting({DynamoDBModule.class, ArchaiusModule.class, NdBenchGuiceModule.class})
+public class DynamoDBProgrammaticKeyValueTest {
+    @Inject
+    ProgrammaticDynamoDBConfiguration configuration;
+    @Inject
+    DefaultDataGenerator dataGenerator;
+
+    AWSCredentialsProvider awsCredentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials("a", "b"));
+
+    DynamoDBAutoscalingConfigurer dynamoDBAutoscalingConfigurer = mock(DynamoDBAutoscalingConfigurer.class);
+    DynamoDBProxyServer server;
+
+    @Before
+    public void setup() throws Exception {
+        server = ServerRunner.createServerFromCommandLineArgs(new String[]{"-inMemory", "-port", "4567"});
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    public void testCreateDynamoDbFromDataGenerator_withoutInit_protectedSetupMethodsNotCalled() {
+        DynamoDBProgrammaticKeyValue sut = spy(new DynamoDBProgrammaticKeyValue(awsCredentialsProvider,
+                configuration, dynamoDBAutoscalingConfigurer));
+        assertNotNull(sut);
+        verify(sut, times(0)).init(any());
+        verify(sut, times(0)).createAndSetDynamoDBClient();
+        verify(sut, times(0)).instantiateDataPlaneOperations(any());
+    }
+
+    @TestPropertyOverride({"ndbench.config.dynamodb.autoscaling=false",
+            "ndbench.config.dynamodb.endpoint=http://localhost:4567",
+            "ndbench.config.dynamodb.region=us-east-1"})
+    @Test
+    public void testCreateDynamoDbFromDataGenerator_withInit_andNoAutoscaling_protectedSetupMethodsCalled() {
+        DynamoDBProgrammaticKeyValue sut = spy(new DynamoDBProgrammaticKeyValue(awsCredentialsProvider,
+                configuration, dynamoDBAutoscalingConfigurer));
+        assertNotNull(sut);
+        assertNotNull(sut);
+        sut.init(dataGenerator);
+        verify(sut, times(1)).createAndSetDynamoDBClient();
+        verify(sut, times(1)).instantiateDataPlaneOperations(any());
+        verify(dynamoDBAutoscalingConfigurer, times(0)).setupAutoscaling(any(), any(), any(), any(), any(), any());
+    }
+
+    @TestPropertyOverride({"ndbench.config.dynamodb.endpoint=http://localhost:4567",
+            "ndbench.config.dynamodb.region=us-east-1"})
+    @Test
+    public void testCreateDynamoDbFromDataGenerator_withInit_andAutoscaling_protectedSetupMethodsCalled() {
+        DynamoDBProgrammaticKeyValue sut = spy(new DynamoDBProgrammaticKeyValue(awsCredentialsProvider,
+                configuration, dynamoDBAutoscalingConfigurer));
+        assertNotNull(sut);
+        sut.init(dataGenerator);
+        verify(dynamoDBAutoscalingConfigurer, times(1)).setupAutoscaling(any(), any(), any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
This change adds some tests to the DynamoDB module, demonstrates testing with DynamoDB local and Gradle, and fixes some null pointer exceptions in DynamoDBProgrammaticKeyValue related to the fact that the encapsulated KeyValue was not delegated to for writeOnce, writeBulk, readOnce, and readBulk