### PR TITLE
updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 * Elassandra
 * Amazon DynamoDB
 * Apache Geode
-* Apache JanusGraph
+* JanusGraph
 * Netflix Dynomite (Redis API)
 * Netflix EVCache (Memcache API)
 


### PR DESCRIPTION
JanusGraph is hosted at the Linux Foundation. It is not an Apache Software Foundation project.
https://www.linuxfoundation.org/blog/the-linux-foundation-welcomes-janusgraph/