### PR TITLE
Running locally and using custom LookupService impl

### DIFF
--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassAstyanaxPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassAstyanaxPlugin.java
@@ -93,7 +93,7 @@ public class CassAstyanaxPlugin implements NdBenchClient {
                     .setDiscoveryType(NodeDiscoveryType.RING_DESCRIBE)
             )
             .withConnectionPoolConfiguration(new ConnectionPoolConfigurationImpl("MyConnectionPool")
-                    .setPort(9160)
+                    .setPort(config.getHostPort())
                     .setMaxConnsPerHost(1)
                     .setSeeds(ClusterContactPoint)
             )

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/configs/CassandraAstynaxConfiguration.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/configs/CassandraAstynaxConfiguration.java
@@ -18,10 +18,19 @@ package com.netflix.ndbench.plugin.configs;
 
 import com.netflix.archaius.api.annotations.Configuration;
 import com.netflix.archaius.api.annotations.DefaultValue;
+import com.netflix.archaius.api.annotations.PropertyName;
 import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
 
 @Configuration(prefix =  NdBenchConstants.PROP_NAMESPACE +  "cass")
 public interface CassandraAstynaxConfiguration extends CassandraConfigurationBase {
+
+    /**
+     * Default to C*'s default thrift port since ndbench doesn't implement cql over Astyanax
+     */
+    @PropertyName(name = "host.port")
+    @DefaultValue("9160")
+    Integer getHostPort();
+
     @DefaultValue("emp_thrift")
     String getCfname();
 

--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/configs/CassandraConfigurationBase.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/configs/CassandraConfigurationBase.java
@@ -24,6 +24,10 @@ public interface CassandraConfigurationBase {
     String getCluster();
 
     @PropertyName(name = "host")
+    // Ignore PMD java rule as inapplicable because we're setting an overridable default
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+    // Default to running locally against local C* host
+    @DefaultValue("127.0.0.1")
     String getHost();
 
     @PropertyName(name = "host.port")

--- a/ndbench-cass-plugins/src/main/resources/setupCassTables.cql
+++ b/ndbench-cass-plugins/src/main/resources/setupCassTables.cql
@@ -1,15 +1,21 @@
-CREATE KEYSPACE IF NOT EXISTS dev1 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '3', 'dc2': '3', 'dc3': '3'}  AND durable_writes = true;
+// Run these cql statements to prepare a C* cluster for Cassandra-related NdBench plugins.
+// Uncomment the appropriate keyspace creation line before executing.
 
-//CassAstyanaxPlugin Plugin
+// Create keyspace dev1 for C* cluster:
+// CREATE KEYSPACE IF NOT EXISTS dev1 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '3', 'dc2': '3', 'dc3': '3'}  AND durable_writes = true;
 
+// Create keyspace dev1 for single C* node:
+// CREATE KEYSPACE IF NOT EXISTS dev1 WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': '1'}  AND durable_writes = true;
+
+// Table for CassAstyanaxPlugin Plugin
 CREATE TABLE IF NOT EXISTS dev1.emp_thrift (key text, column1 int, value text, PRIMARY KEY ((key), column1)) WITH COMPACT STORAGE;
 
-//CassJavaDriverPlugin Plugin
+// Table for CassJavaDriverPlugin Plugin
 CREATE TABLE IF NOT EXISTS dev1.empl (emp_uname varchar primary key, emp_first varchar, emp_last varchar, emp_dept varchar);
 
-//CassJavaDriverGeneric Plugin
+// Table for CassJavaDriverGeneric Plugin
 CREATE TABLE IF NOT EXISTS dev1.emp (key text, column1 int, value text, PRIMARY KEY (key, column1)) WITH CLUSTERING ORDER BY (column1 ASC);
 
-//CassJavaDriverBatch Plugin
+// Tables for CassJavaDriverBatch Plugin
 CREATE TABLE IF NOT EXISTS dev1.emp (cyclist_name text, expense_id int, amount float, balance float static, description text, paid boolean, PRIMARY KEY (cyclist_name, expense_id)) WITH CLUSTERING ORDER BY (expense_id ASC);
 CREATE TABLE IF NOT EXISTS dev1.test2 (expense_id int, cyclist_name text, PRIMARY KEY (expense_id, cyclist_name)) WITH CLUSTERING ORDER BY (cyclist_name ASC);

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/config/GuiceInjectorProvider.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/config/GuiceInjectorProvider.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class GuiceInjectorProvider {
-    private List<Module> getModuleList(AbstractModule... modules) {
+    List<Module> getModuleList(AbstractModule... modules) {
         List<Module> moduleList = Lists.newArrayList();
 
         // Add default list of modules

--- a/ndbench-evcache-plugins/src/main/java/com/netflix/ndbench/plugin/evcache/configs/EVCachePluginModule.java
+++ b/ndbench-evcache-plugins/src/main/java/com/netflix/ndbench/plugin/evcache/configs/EVCachePluginModule.java
@@ -19,24 +19,22 @@ package com.netflix.ndbench.plugin.evcache.configs;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
-import com.netflix.discovery.guice.EurekaModule;
 import com.netflix.evcache.EVCacheModule;
 import com.netflix.evcache.connection.ConnectionModule;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPluginGuiceModule;
 
 /**
- * 
- * @author ipapapa
+ * Note this module relies on LookupService (e.g. Eureka). But to avoid conflicts with different modules binding
+ * different LookupService implementations, we defer the install to an application-level module.
  *
+ * @author ipapapa
  */
 @NdBenchClientPluginGuiceModule
 public class EVCachePluginModule extends AbstractModule {
     @Override
     protected void configure() {
-        install(new EurekaModule());
         install(new EVCacheModule());
         install(new ConnectionModule());
-        
     }
 
     @Provides

--- a/ndbench-web/src/main/java/com/netflix/ndbench/core/config/WebGuiceInjectorProvider.java
+++ b/ndbench-web/src/main/java/com/netflix/ndbench/core/config/WebGuiceInjectorProvider.java
@@ -1,0 +1,52 @@
+package com.netflix.ndbench.core.config;
+
+import com.google.inject.*;
+import com.google.inject.util.Modules;
+import com.netflix.appinfo.EurekaInstanceConfig;
+import com.netflix.appinfo.providers.MyDataCenterInstanceConfigProvider;
+import com.netflix.discovery.guice.EurekaModule;
+import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.List;
+
+/**
+ * ndbench-web app-specific GuiceInjectorProvider impl which adds EurekaModule (local or AWS) to avoid conflicts from
+ * different modules instantiating different LookupService implementations.
+ * <p/>
+ * {@inheritDoc}
+ */
+public class WebGuiceInjectorProvider extends GuiceInjectorProvider {
+    /**
+     * GuiceInjectorProvider impl which adds EurekaModule (local or AWS) to avoid conflicts from different modules
+     * instantiating different LookupService implementations.
+     * <p/>
+     * {@inheritDoc}
+     */
+    @Override
+    public Injector getInjector(AbstractModule... modules) {
+        List<Module> moduleList = getModuleList(modules);
+
+        // Add EurekaModule for any plugins which require it.
+        // Currently needed only for ndbench-evcache-plugins, but we don't add EurekaModule to module-level
+        // because choice of LookupService impl should be made at application level to avoid conflicts from
+        // different modules creating different LookupService implementations.
+        String discoveryEnv = System.getenv(NdBenchConstants.DISCOVERY_ENV);
+        if(StringUtils.isBlank(discoveryEnv) || discoveryEnv == "local"){
+            moduleList.add(Modules.override(new EurekaModule()).with(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    // Default EurekaInstanceConfig is CloudInstanceConfig, which works only in AWS env.
+                    // When not in AWS, override to use MyDataCenterInstanceConfig instead.
+                    bind(EurekaInstanceConfig.class).toProvider(MyDataCenterInstanceConfigProvider.class).in(Scopes.SINGLETON);
+                }
+            }));
+        } else {
+            moduleList.add(new EurekaModule());
+        }
+
+        Injector injector = Guice.createInjector(moduleList);
+        injector.getInstance(IConfiguration.class).initialize();
+        return injector;
+    }
+}

--- a/ndbench-web/src/main/java/com/netflix/ndbench/core/config/WebGuiceInjectorProvider.java
+++ b/ndbench-web/src/main/java/com/netflix/ndbench/core/config/WebGuiceInjectorProvider.java
@@ -13,14 +13,14 @@ import java.util.List;
 /**
  * ndbench-web app-specific GuiceInjectorProvider impl which adds EurekaModule (local or AWS) to avoid conflicts from
  * different modules instantiating different LookupService implementations.
- * <p/>
+ * <p>
  * {@inheritDoc}
  */
 public class WebGuiceInjectorProvider extends GuiceInjectorProvider {
     /**
      * GuiceInjectorProvider impl which adds EurekaModule (local or AWS) to avoid conflicts from different modules
      * instantiating different LookupService implementations.
-     * <p/>
+     * <p>
      * {@inheritDoc}
      */
     @Override

--- a/ndbench-web/src/main/java/com/netflix/ndbench/defaultimpl/InjectedWebListener.java
+++ b/ndbench-web/src/main/java/com/netflix/ndbench/defaultimpl/InjectedWebListener.java
@@ -20,6 +20,7 @@ import com.google.inject.Injector;
 import com.google.inject.servlet.GuiceServletContextListener;
 import com.google.inject.servlet.ServletModule;
 import com.netflix.ndbench.core.config.GuiceInjectorProvider;
+import com.netflix.ndbench.core.config.WebGuiceInjectorProvider;
 import com.sun.jersey.api.core.PackagesResourceConfig;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.sun.jersey.spi.container.servlet.ServletContainer;
@@ -35,7 +36,7 @@ public class InjectedWebListener extends GuiceServletContextListener
     @Override
     protected Injector getInjector()
     {
-        return new GuiceInjectorProvider().getInjector( new JaxServletModule());
+        return new WebGuiceInjectorProvider().getInjector( new JaxServletModule());
     }
 
     public static class JaxServletModule extends ServletModule

--- a/ndbench-web/src/main/resources/laptop.properties
+++ b/ndbench-web/src/main/resources/laptop.properties
@@ -1,1 +1,13 @@
-foo=bar
+# Do not try to register with discovery since we don't want others to discover our laptop.
+netflix.discovery.registration.enabled=false
+eureka.registration.enabled=false
+eureka.shouldFetchRegistry=false
+
+# Since we are not on AWS we don't have an instance ID and
+# we don't want Eureka to check for that and fail initialization.
+netflix.appinfo.validateInstanceId=false
+
+# Since we are not in AWS let's not make a call to EC2 to ask for EC2 node specific info.
+netflix.appinfo.doNotInitWithAmazonInfo=true
+
+DISCOVERY_ENV=local


### PR DESCRIPTION
- Fixed ndbench-evcache-plugin issues preventing NdBench from successfully starting in local env and preventing extensions from setting a different LookupService impl.
- Changed defaults of ndbench-cass-plugins to consistently support running in local env (most of the defaults already supported local env, but a few did not).