### PR TITLE
Remove the aws module dependency for config initialization in dax and dynamo modules

### DIFF
--- a/ndbench-aws/src/main/java/com/netflix/ndbench/aws/defaultimpl/AwsDefaultsModule.java
+++ b/ndbench-aws/src/main/java/com/netflix/ndbench/aws/defaultimpl/AwsDefaultsModule.java
@@ -5,7 +5,10 @@ package com.netflix.ndbench.aws.defaultimpl;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPluginGuiceModule;
+import com.netflix.ndbench.aws.config.CredentialsConfiguration;
 import com.netflix.ndbench.aws.config.NdbenchAWSCredentialProvider;
 
 /**
@@ -19,5 +22,10 @@ public class AwsDefaultsModule extends AbstractModule
     protected void configure()
     {
         bind(AWSCredentialsProvider.class).to(NdbenchAWSCredentialProvider.class);
+    }
+
+    @Provides
+    CredentialsConfiguration getCredentialsConfiguration(ConfigProxyFactory factory) {
+        return factory.newProxy(CredentialsConfiguration.class);
     }
 }

--- a/ndbench-dax-plugins/src/main/java/com/netflix/ndbench/plugin/dax/configs/DaxModule.java
+++ b/ndbench-dax-plugins/src/main/java/com/netflix/ndbench/plugin/dax/configs/DaxModule.java
@@ -16,12 +16,10 @@
  */
 package com.netflix.ndbench.plugin.dax.configs;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPluginGuiceModule;
-import com.netflix.ndbench.aws.config.CredentialsConfiguration;
 
 /**
  * 
@@ -39,10 +37,5 @@ public class DaxModule extends AbstractModule {
     @Provides
     DaxConfiguration getDaxConfiguration(ConfigProxyFactory factory) {
         return factory.newProxy(DaxConfiguration.class);
-    }
-
-    @Provides
-    CredentialsConfiguration getCredentialsConfiguration(ConfigProxyFactory factory) {
-        return factory.newProxy(CredentialsConfiguration.class);
     }
 }

--- a/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/configs/DynamoDBModule.java
+++ b/ndbench-dynamodb-plugins/src/main/java/com/netflix/ndbench/plugin/dynamodb/configs/DynamoDBModule.java
@@ -20,7 +20,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.archaius.ConfigProxyFactory;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPluginGuiceModule;
-import com.netflix.ndbench.aws.config.CredentialsConfiguration;
 
 /**
  * 
@@ -45,8 +44,4 @@ public class DynamoDBModule extends AbstractModule {
         return factory.newProxy(ProgrammaticDynamoDBConfiguration.class);
     }
 
-    @Provides
-    CredentialsConfiguration getCredentialsConfiguration(ConfigProxyFactory factory) {
-        return factory.newProxy(CredentialsConfiguration.class);
-    }
 }


### PR DESCRIPTION
Remove the aws module dependency for config initialization in dax and dynamo modules