### PR TITLE
Deleting unused gradle download plugin from build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
 
 plugins {
     id 'nebula.netflixoss' version '5.1.1'
-    id "de.undercouch.download" version "3.4.2"
 
 }
 


### PR DESCRIPTION
Deleting it as the use of `de.undercouch.download` is not there anymore. 