### PR TITLE
Adding checksum validation capability

### DIFF
--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassAstyanaxPlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/cass/CassAstyanaxPlugin.java
@@ -42,6 +42,7 @@ import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.api.plugin.NdBenchClient;
 import com.netflix.ndbench.api.plugin.annotations.NdBenchClientPlugin;
 import com.netflix.ndbench.core.config.IConfiguration;
+import com.netflix.ndbench.core.util.CheckSumUtil;
 import com.netflix.ndbench.plugin.cass.astyanax.CassA6XManager;
 import com.netflix.ndbench.plugin.configs.CassandraAstynaxConfiguration;
 
@@ -124,6 +125,18 @@ public class CassAstyanaxPlugin implements NdBenchClient {
         if (!result.isEmpty()) {
             if (result.size() < (config.getColsPerRow())) {
                 throw new Exception("Num Cols returned not ok " + result.size());
+            }
+
+            if (coreConfig.isValidateChecksum())
+            {
+                for (int i = 0; i < result.size(); i++)
+                {
+                    String value = result.getColumnByIndex(i).getStringValue();
+                    if (!CheckSumUtil.isChecksumValid(value))
+                    {
+                        throw new Exception(String.format("Value %s is corrupt. Key %s.", value, key));
+                    }
+                }
             }
         } else {
             return CacheMiss;

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/config/IConfiguration.java
@@ -85,6 +85,12 @@ public interface IConfiguration {
     @DefaultValue("5000")
     int getDataSizeUpperBound();
 
+    @DefaultValue("false")
+    boolean isGenerateChecksum();
+
+    @DefaultValue("false")
+    boolean isValidateChecksum();
+
 
     //Tunable configs
     @DefaultValue("100")
@@ -117,5 +123,4 @@ public interface IConfiguration {
      */
     @DefaultValue("0.01")
     Float getAutoTuneWriteFailureRatioThreshold();
-
 }

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/generators/DefaultDataGenerator.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/generators/DefaultDataGenerator.java
@@ -32,6 +32,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.ndbench.api.plugin.DataGenerator;
 import com.netflix.ndbench.core.config.IConfiguration;
+import com.netflix.ndbench.core.util.CheckSumUtil;
 import org.joda.time.DateTime;
 
 /**
@@ -120,10 +121,12 @@ public class DefaultDataGenerator implements DataGenerator
     private String generateRandomString(int length)
     {
         StringBuilder builder = new StringBuilder();
-        while (builder.length()<length)
+        while (builder.length() < length)
         {
             builder.append(Long.toHexString(vRandom.nextLong()));
         }
-        return builder.toString().substring(0,length);
+
+        String randomString = builder.toString().substring(0, length);
+        return config.isGenerateChecksum() ? CheckSumUtil.appendCheckSumAndEncodeBase64(randomString, false) : randomString;
     }
 }

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/util/CheckSumUtil.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/util/CheckSumUtil.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright 2019 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.ndbench.core.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.zip.CRC32;
+import java.util.zip.Checksum;
+
+/**
+ * @author Sumanth Pasupuleti
+ *
+ * CheckSumUtil contains methods around generation and validation of CRC32 based checksum
+ */
+public class CheckSumUtil
+{
+    /**
+     * Generates a checksum of the input string or an abridged version of the input string (depending upon append param)
+     * and returns a base64 encoded string of the input string (or an abridged version of it) + checksum.
+     * Returned string is usually longer than the input string. 33% overhead comes from base64 encoding, and the rest depends
+     * on append param.
+     *
+     * Future enhancement: This method can be further enhanced by generating checksum for every x-byte block of the input string. Validator can then
+     * validate checksum at block level and bail out of parsing further blocks when an invalid checksum is encountered.
+     * @param inputString string for which checksum has to be generated and appended to
+     * @param append If true, checksum is generated for the entire input string and checksum (8 bytes) is appended to the input string
+     *               after which it is base64 encoded.
+     *               If false, last 8 bytes of the input string are discarded to make it an abridged version of the input string
+     *               and checksum (8 bytes) is appended to the input string after which it is base64 encoded.
+     *               This is primarily useful to have a control on the length of the returned string relative to the length of the input string.
+     * @return Base64 encoded String of (input string + checksum)
+     */
+    public static String appendCheckSumAndEncodeBase64(String inputString, boolean append)
+    {
+        if (!append)
+        {
+            // crc32 generates a checksum of type long (8 bytes), so we truncate the last 8 bytes of the original string
+            // and replace it with the checksum instead of just appending the checksum which is the case if append is false.
+            inputString = inputString.substring(0, inputString.length() - 8);
+        }
+
+        Checksum checksum = new CRC32();
+        byte[] inputStringInBytes = inputString.getBytes(StandardCharsets.UTF_8);
+        checksum.update(inputStringInBytes, 0, inputStringInBytes.length);
+        byte[] checksumInBytes = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).putLong(checksum.getValue()).array();
+
+        // append input string bytes and checksum bytes
+        byte[] output = new byte[inputStringInBytes.length + checksumInBytes.length];
+        System.arraycopy(inputStringInBytes, 0, output, 0, inputStringInBytes.length);
+        System.arraycopy(checksumInBytes, 0, output, inputStringInBytes.length, checksumInBytes.length);
+
+        // return Base64 encoded string of the resulting concatenated bytes.
+        return Base64.getEncoder().encodeToString(output);
+    }
+
+    /**
+     * Assumes input string is Base64 encoded, and assumes checksum is the last 8 bytes.
+     * Base64 decodes the input string, extracts original string bytes and checksum bytes, generates checksum from the
+     * extracted string bytes, and validates against the extracted checksum bytes.
+     * @param encodedInput
+     * @return true if the checksum is correct, false otherwise
+     */
+    public static boolean isChecksumValid(String encodedInput)
+    {
+        byte[] inputInBytes = Base64.getDecoder().decode(encodedInput);
+        // assumes last 8 bytes to be checksum and remaining bytes to be the original input string
+        byte[] extractedInputStringInBytes = Arrays.copyOfRange(inputInBytes, 0, inputInBytes.length - 8);
+        byte[] extractedChecksumInBytes = Arrays.copyOfRange(inputInBytes, inputInBytes.length - 8, inputInBytes.length);
+
+        Checksum checksum = new CRC32();
+        checksum.update(extractedInputStringInBytes, 0, extractedInputStringInBytes.length);
+        byte[] generatedChecksumInBytes = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).putLong(checksum.getValue()).array();
+        return Arrays.equals(extractedChecksumInBytes, generatedChecksumInBytes);
+    }
+}

--- a/ndbench-core/src/test/java/com/netflix/ndbench/core/util/ChecksumUtilTest.java
+++ b/ndbench-core/src/test/java/com/netflix/ndbench/core/util/ChecksumUtilTest.java
@@ -1,0 +1,27 @@
+package com.netflix.ndbench.core.util;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Sumanth Pasupuleti
+ */
+public class ChecksumUtilTest
+{
+    @Test
+    public void testChecksumGenerationAndValidationWithAppendFalse()
+    {
+        String randomString = RandomStringUtils.random(128);
+        String encodedString = CheckSumUtil.appendCheckSumAndEncodeBase64(randomString, false);
+        Assert.assertTrue(CheckSumUtil.isChecksumValid(encodedString));
+    }
+
+    @Test
+    public void testChecksumGenerationAndValidationWithAppendTrue()
+    {
+        String randomString = RandomStringUtils.random(128);
+        String encodedString = CheckSumUtil.appendCheckSumAndEncodeBase64(randomString, true);
+        Assert.assertTrue(CheckSumUtil.isChecksumValid(encodedString));
+    }
+}

--- a/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AbstractPluginTest.java
+++ b/ndbench-es-plugins/src/test/java/com/netflix/ndbench/plugin/es/AbstractPluginTest.java
@@ -187,6 +187,12 @@ public class AbstractPluginTest {
             }
 
             @Override
+            public boolean isGenerateChecksum() { return false; }
+
+            @Override
+            public boolean isValidateChecksum() { return false; }
+
+            @Override
             public int getReadRateLimit() {
                 return 0;
             }
@@ -220,7 +226,6 @@ public class AbstractPluginTest {
             public Float getAutoTuneWriteFailureRatioThreshold() {
                 return maxAcceptableWriteFailures;
             }
-            
 
         };
     }


### PR DESCRIPTION
This feature adds the capability to do checksum validation for "values". Checksum can be included into the values by the DefaultDataGenerator based on a configurable value, and a reader can choose to validate the checksum of the value read, based on a configurable value.

Having this capability is useful to validate, say, the correctness of a datastore, at least in terms of corruption of the values being written.