### PR TITLE
Removing retries on backfill operation failures

### DIFF
--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/DataBackfill.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/DataBackfill.java
@@ -112,12 +112,12 @@ public class DataBackfill {
                 while (k < endKey && !stop.get()) {
                     try {
                         String key = "T" + k;
-                        String result = backfillOperation.process(client, key);
-                        logger.debug("Backfill Key:" + key + " | Result: " + result);
                         k++;
                         count.incrementAndGet();
+                        String result = backfillOperation.process(client, key);
+                        logger.info("Backfill Key:" + key + " | Result: " + result);
                     } catch (Exception e) {
-                        logger.error("Retrying after failure", e);
+                        logger.error("Exception in processing backfill write. Key: T{}", k, e);
                     }
                 }
 


### PR DESCRIPTION
Removing retries on backfill operation failures, since it could lead to long-running backfill operations.