### PR TITLE
CassJavaDriverGeneric: add options to disable use of batch writes

### DIFF
--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/configs/CassandraGenericConfiguration.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/configs/CassandraGenericConfiguration.java
@@ -23,6 +23,13 @@ import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
 public interface CassandraGenericConfiguration extends CassandraConfigurationBase {
     @DefaultValue("2")
     Integer getRowsPerPartition();
+
     @DefaultValue("5")
     Integer getColsPerRow();
+
+    @DefaultValue("false")
+    Boolean getUseBatchWrites();
+
+    @DefaultValue("false")
+    Boolean getValidateRowsPerPartition();
 }


### PR DESCRIPTION
The use of `BATCH` in `CassJavaDriverGeneric` allows the driver to write multiple rows in a single call to `writeSingle`. Its sometimes desirable, however, to have `writeSingle` to truly write a single row so that `BATCH` is not used.

This can cause the row count validation to fail since not every row is written to every partition. An additional configuration has been added to disable this validation.