### PR TITLE
remove log for protocol version

### DIFF
--- a/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/datastax4/CJavaDriverBasePlugin.java
+++ b/ndbench-cass-plugins/src/main/java/com/netflix/ndbench/plugin/datastax4/CJavaDriverBasePlugin.java
@@ -69,9 +69,6 @@ public abstract class CJavaDriverBasePlugin<Config extends CassandraConfiguratio
         this.session = cassJavaDriverManager.getSession(sessionName, sessionContactPoint, connections, port,
                 username, password);
 
-        logger.info("Protocol version in use: {}", session.getContext().getConfig().getDefaultProfile().getString(
-                DefaultDriverOption.PROTOCOL_VERSION));
-
         if(config.getCreateSchema())
         {
             logger.info("Trying to upsert schema");


### PR DESCRIPTION
remove the log for protocol version, this config is not required value and won't exist in a lot of cases. Having this log will require this value to be set otherwise there will be config not exist error. 