### PR TITLE
Implement allowedOrigins whitelist

### DIFF
--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/filters/CorsResponseFilter.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/filters/CorsResponseFilter.java
@@ -1,0 +1,30 @@
+package com.netflix.ndbench.core.filters;
+
+import com.netflix.ndbench.core.config.IConfiguration;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.ext.Provider;
+import java.util.Arrays;
+import java.util.List;
+
+@Provider
+public class CorsResponseFilter implements ContainerResponseFilter {
+  public static final Logger LOGGER = LoggerFactory.getLogger(CorsResponseFilter.class);
+  @Inject IConfiguration config;
+
+  @Override
+  public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
+    List<String> allowedOrigins = Arrays.asList(config.getAllowedOrigins().split(";"));
+    String origin = request.getRequestHeaders().getFirst("Origin");
+    if (allowedOrigins.contains(origin)) {
+      response.getHttpHeaders().add("Access-Control-Allow-Origin", origin);
+      response.getHttpHeaders().add("Vary", "Origin");
+    }
+    return response;
+  }
+}

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/resources/NDBenchConfigResource.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/resources/NDBenchConfigResource.java
@@ -20,7 +20,6 @@ import com.google.inject.Inject;
 import com.netflix.archaius.api.config.SettableConfig;
 import com.netflix.archaius.api.inject.RuntimeLayer;
 import com.netflix.ndbench.api.plugin.common.NdBenchConstants;
-import com.netflix.ndbench.core.NdBenchDriver;
 import com.netflix.ndbench.core.config.IConfiguration;
 import com.netflix.ndbench.core.config.TunableConfig;
 import com.netflix.ndbench.core.util.RestUtil;
@@ -41,16 +40,13 @@ public class NDBenchConfigResource {
     private static final Logger logger = LoggerFactory.getLogger(NDBenchConfigResource.class);
 
     private final IConfiguration config;
-    private final NdBenchDriver ndBenchDriver;
     private final SettableConfig settableConfig;
 
     @Inject
     public NDBenchConfigResource(IConfiguration config,
-                                 NdBenchDriver ndBenchDriver,
                                  @RuntimeLayer SettableConfig settableConfig
                                  ) {
         this.config = config;
-        this.ndBenchDriver = ndBenchDriver;
         this.settableConfig = settableConfig;
 
     }

--- a/ndbench-core/src/main/java/com/netflix/ndbench/core/util/RestUtil.java
+++ b/ndbench-core/src/main/java/com/netflix/ndbench/core/util/RestUtil.java
@@ -52,10 +52,6 @@ public class RestUtil {
     static <T> Response sendResponse(Response.Status status, T object, IConfiguration config)
     {
         Response.ResponseBuilder builder = Response.status(status).type(javax.ws.rs.core.MediaType.APPLICATION_JSON).entity(object);
-        if (!config.getAllowedOrigins().isEmpty()) {
-            builder = builder.header("Access-Control-Allow-Origin", config.getAllowedOrigins())
-                    .header("Vary", "Origin");
-        }
         return builder.build();
     }
 

--- a/ndbench-core/src/main/resources/application.properties
+++ b/ndbench-core/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 ndbench.config.numKeys=10000
 ndbench.config.writeRateLimit=35
 ndbench.config.readRateLimit=45
-ndbench.config.allowedOrigins=http://localhost:8080
+ndbench.config.allowedOrigins=http://localhost:8080;http://testlocalhost:8080

--- a/ndbench-web/src/main/java/com/netflix/ndbench/defaultimpl/InjectedWebListener.java
+++ b/ndbench-web/src/main/java/com/netflix/ndbench/defaultimpl/InjectedWebListener.java
@@ -44,8 +44,12 @@ public class InjectedWebListener extends GuiceServletContextListener
         protected void configureServlets()
         {
             Map<String, String> params = new HashMap<>();
-            params.put(PackagesResourceConfig.PROPERTY_PACKAGES, "unbound");
-            params.put("com.sun.jersey.config.property.packages", "com.netflix.ndbench.core.resources");
+            String packages =
+                "com.netflix.ndbench.core.resources;" +
+                "com.netflix.ndbench.core.filters;";
+            params.put(PackagesResourceConfig.PROPERTY_PACKAGES, packages);
+            params.put(PackagesResourceConfig.PROPERTY_CONTAINER_RESPONSE_FILTERS,
+                "com.netflix.ndbench.core.filters.CorsResponseFilter");
             params.put(ServletContainer.PROPERTY_FILTER_CONTEXT_PATH, "/REST");
             serve("/REST/*").with(GuiceContainer.class, params);
         }


### PR DESCRIPTION
The allowed origins whitelist should be defined as a semicolon-delimited list of CORS origins at property `ndbench.config.allowedOrigins`. This property is not dynamically configurable; change requires server restart.